### PR TITLE
Improve Export Logic

### DIFF
--- a/fast64_internal/mk64/mk64_operators.py
+++ b/fast64_internal/mk64/mk64_operators.py
@@ -196,7 +196,16 @@ class MK64_ExportCourse(Operator):
                 applyRotation([root], math.radians(-90), "X")
 
             if context.object and context.mode != prev_mode:
-                bpy.ops.object.mode_set(mode=prev_mode)
+                restore_mode(context, prev_mode)
+
+    def restore_mode(context, prev_mode):
+        if not context.object:
+            return
+
+        if prev_mode.startswith("EDIT"):
+            bpy.ops.object.mode_set(mode="EDIT")
+        elif prev_mode in {"OBJECT", "POSE", "SCULPT"}:
+            bpy.ops.object.mode_set(mode=prev_mode)
 
 
 mk64_operator_classes = (MK64_ImportCourseDL, MK64_ExportCourse)

--- a/fast64_internal/mk64/mk64_operators.py
+++ b/fast64_internal/mk64/mk64_operators.py
@@ -196,16 +196,14 @@ class MK64_ExportCourse(Operator):
                 applyRotation([root], math.radians(-90), "X")
 
             if context.object and context.mode != prev_mode:
-                restore_mode(context, prev_mode)
+                if not context.object:
+                    return
 
-    def restore_mode(context, prev_mode):
-        if not context.object:
-            return
+                if prev_mode.startswith("EDIT"):
+                    bpy.ops.object.mode_set(mode="EDIT")
+                elif prev_mode in {"OBJECT", "POSE", "SCULPT"}:
+                    bpy.ops.object.mode_set(mode=prev_mode)
 
-        if prev_mode.startswith("EDIT"):
-            bpy.ops.object.mode_set(mode="EDIT")
-        elif prev_mode in {"OBJECT", "POSE", "SCULPT"}:
-            bpy.ops.object.mode_set(mode=prev_mode)
 
 
 mk64_operator_classes = (MK64_ImportCourseDL, MK64_ExportCourse)

--- a/fast64_internal/mk64/mk64_operators.py
+++ b/fast64_internal/mk64/mk64_operators.py
@@ -103,7 +103,7 @@ class MK64_ImportCourseDL(Operator):
 
 class MK64_ExportCourse(Operator):
     bl_idname = "scene.mk64_export_course"
-    bl_label = "Export Course"
+    bl_label = "Export Track"
 
     def execute(self, context):
         mk64_props: MK64_Properties = context.scene.fast64.mk64

--- a/fast64_internal/mk64/mk64_operators.py
+++ b/fast64_internal/mk64/mk64_operators.py
@@ -109,6 +109,7 @@ class MK64_ExportCourse(Operator):
         mk64_props: MK64_Properties = context.scene.fast64.mk64
 
         prev_mode = context.mode
+        prev_active = context.view_layer.objects.active
         root = None
         rotation_applied = False
 
@@ -196,10 +197,8 @@ class MK64_ExportCourse(Operator):
                 applyRotation([root], math.radians(-90), "X")
 
             if context.object and context.mode != prev_mode:
-                if not context.object:
-                    return
-
-                if prev_mode.startswith("EDIT"):
+                context.view_layer.objects.active = prev_active
+                if prev_mode.startswith("EDIT") and context.object.type in {"MESH", "CURVE", "ARMATURE"}:
                     bpy.ops.object.mode_set(mode="EDIT")
                 elif prev_mode in {"OBJECT", "POSE", "SCULPT"}:
                     bpy.ops.object.mode_set(mode=prev_mode)

--- a/fast64_internal/mk64/mk64_panels.py
+++ b/fast64_internal/mk64/mk64_panels.py
@@ -34,7 +34,6 @@ class MK64_ImportCourseDLPanel(MK64_Panel):
 class MK64_ExportCoursePanel(MK64_Panel):
     bl_label = "SpaghettiKart Track Export"
     bl_idname = "MK64_PT_export_course"
-    bl_context = "objectmode"
 
     def draw(self, context):
         col = self.layout.column()


### PR DESCRIPTION
* Edit mode no longer makes export window disappear
* Make easier to export
  * Object/Edit mode doesn't matter. It switches to object mode, exports, re-selects your object and puts it back into your previous mode.
  * Can select any object under the empty. If outside the empty it reminds you to select the empty.
* Rename button