### PR TITLE
Set Default Scaling for SpaghettiKart

### DIFF
--- a/fast64_internal/mk64/mk64_properties.py
+++ b/fast64_internal/mk64/mk64_properties.py
@@ -90,7 +90,7 @@ class MK64_Properties(PropertyGroup):
     course_DL_import_settings: bpy.props.PointerProperty(type=MK64_ImportProperties)
     # exporter settings, merge with above later?
     course_export_settings: bpy.props.PointerProperty(type=MK64_ExportProperties)
-    scale: FloatProperty(name="F3D Blender Scale", default=25, update=on_update_render_settings)
+    scale: FloatProperty(name="F3D Blender Scale", default=100, update=on_update_render_settings)
 
     @staticmethod
     def upgrade_changed_props():


### PR DESCRIPTION
It's been confirmed that a scale of 100 is correct.

This means
* Blender coordinates to in-game coordinates is * 100
* in-game coordinates to blender coordinates is / 100

The issue was that at the time there were no tools to confirm the correct scaling. And people were making maps where the road was way too small. And objects like buildings were way too big.

So maps were being scaled to 25, and then hacked to look okay. 