### PR TITLE
Hd texture export

### DIFF
--- a/fast64_internal/hm64/__init__.py
+++ b/fast64_internal/hm64/__init__.py
@@ -10,6 +10,7 @@ def hm64_register():
     from .mk64 import register as register_mk64
     from .z64.panels import register as register_z64_panels
     from .z64.skeleton import register as register_z64_skeleton
+    from .z64.model_classes_hm64 import register as register_z64_model_classes_hm64
 
     register_f3d_gbi_hm64()
     register_f3d_material_hm64()
@@ -18,6 +19,7 @@ def hm64_register():
     register_mk64()
     register_z64_skeleton()
     register_z64_panels()
+    register_z64_model_classes_hm64()
 
 
 def hm64_unregister():
@@ -28,7 +30,9 @@ def hm64_unregister():
     from .mk64 import unregister as unregister_mk64
     from .z64.panels import unregister as unregister_z64_panels
     from .z64.skeleton import unregister as unregister_z64_skeleton
+    from .z64.model_classes_hm64 import unregister as unregister_z64_model_classes_hm64
 
+    unregister_z64_model_classes_hm64()
     unregister_z64_panels()
     unregister_z64_skeleton()
     unregister_mk64()

--- a/fast64_internal/hm64/f3d/f3d_material_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_material_hm64.py
@@ -53,6 +53,12 @@ def _update_tex_values_field(self: Material, texProperty: TextureProperty, tex_s
     inputs[str_index + " S Mask"].default_value = texProperty.S.mask
     inputs[str_index + " T Mask"].default_value = texProperty.T.mask
 
+    inputs[str_index + " MirrorX"].default_value = 1 if texProperty.S.mirror > 0 else 0
+    inputs[str_index + " MirrorY"].default_value = 1 if texProperty.T.mirror > 0 else 0
+
+    inputs[str_index + " S Shift"].default_value = texProperty.S.shift
+    inputs[str_index + " T Shift"].default_value = texProperty.T.shift
+
 
 class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
     bl_idname = "material.hm64_apply_reference_size"

--- a/fast64_internal/hm64/f3d/f3d_material_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_material_hm64.py
@@ -35,10 +35,7 @@ def _update_tex_values_field(self: Material, texProperty: TextureProperty, tex_s
 
     if texProperty.autoprop:
         tex_size = tuple(tex_size)
-        if texProperty.tex_format != "RGBA32":
-            native_size = tex_size
-        else:
-            native_size = resolveNativeSize(texProperty, tex_size)
+        native_size = resolveNativeSize(texProperty, tex_size)
         setAutoProp(texProperty.S, native_size[0])
         setAutoProp(texProperty.T, native_size[1])
 
@@ -71,9 +68,6 @@ class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
     def execute(self, context):
         material = context.material
         texProp = getattr(material.f3d_mat, "tex" + str(self.combinerTexIndex))
-        if texProp.tex_format != "RGBA32":
-            self.report({"ERROR"}, "Set Format to RGBA32 first.")
-            return {"CANCELLED"}
         native_size = getNativeSizeOverride(texProp)
         if native_size is None:
             self.report({"ERROR"}, "Set Native Width and Native Height first.")
@@ -163,11 +157,11 @@ def _ui_image(
         row.prop(textureProp, "is_vanilla_texture", text="Is Vanilla Texture?")
         row = box.row(align=True)
         row.prop(textureProp, "texture_internal_path", text="Internal Path")
-        if is_hm64_feature_set() and textureProp.tex_format == "RGBA32":
+        if is_hm64_feature_set():
             row = box.row(align=True)
             row.prop(textureProp, "hd_native_width", text="Native Width")
             row.prop(textureProp, "hd_native_height", text="Native Height")
-    elif is_hm64_feature_set() and textureProp.tex_format == "RGBA32":
+    elif is_hm64_feature_set():
         row = box.row(align=True)
         row.prop(textureProp, "hd_native_width", text="Native Width")
         row.prop(textureProp, "hd_native_height", text="Native Height")

--- a/fast64_internal/hm64/f3d/f3d_material_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_material_hm64.py
@@ -2,16 +2,87 @@ from __future__ import annotations
 
 import bpy
 from bpy.types import Material, UILayout
+from bpy.utils import register_class, unregister_class
 
 from ...f3d import f3d_material as base
-from ...f3d.f3d_material import F3DMaterialProperty, F3DPanel, TextureProperty
+from ...f3d.f3d_material import F3DMaterialProperty, F3DPanel, TextureProperty, setAutoProp
+
+from ..utility import is_hm64
+from .f3d_texture_writer_hm64 import getNativeSizeOverride, resolveNativeSize
 
 
 _ORIGINALS = {}
 
+_HD_NATIVE_SIZES = (4, 8, 16, 32, 64, 128, 256)
+_HD_NATIVE_SIZE_ITEMS = [("0", "Auto (TMEM-fit)", "Divide down to fit the TMEM budget; may not match the original asset's true resolution")] + [
+    (str(v), str(v), f"{v} texels") for v in _HD_NATIVE_SIZES
+]
+
 
 def is_hm64_feature_set() -> bool:
     return True
+
+
+def _update_tex_values_field(self: Material, texProperty: TextureProperty, tex_size: list[int], tex_index: int):
+    if not is_hm64():
+        return _ORIGINALS["update_tex_values_field"](self, texProperty, tex_size, tex_index)
+
+    nodes = self.node_tree.nodes
+    textureSettings = nodes["TextureSettings"]
+    inputs = textureSettings.inputs
+
+    base.set_texture_size(self, tex_size, tex_index)
+
+    if texProperty.autoprop:
+        tex_size = tuple(tex_size)
+        if texProperty.tex_format != "RGBA32":
+            native_size = tex_size
+        else:
+            native_size = resolveNativeSize(texProperty, tex_size)
+        setAutoProp(texProperty.S, native_size[0])
+        setAutoProp(texProperty.T, native_size[1])
+
+    str_index = str(tex_index)
+
+    inputs[str_index + " S Low"].default_value = base.trunc_10_2(texProperty.S.low)
+    inputs[str_index + " T Low"].default_value = base.trunc_10_2(texProperty.T.low)
+
+    inputs[str_index + " S High"].default_value = base.trunc_10_2(texProperty.S.high)
+    inputs[str_index + " T High"].default_value = base.trunc_10_2(texProperty.T.high)
+
+    inputs[str_index + " ClampX"].default_value = 1 if texProperty.S.clamp else 0
+    inputs[str_index + " ClampY"].default_value = 1 if texProperty.T.clamp else 0
+
+    inputs[str_index + " S Mask"].default_value = texProperty.S.mask
+    inputs[str_index + " T Mask"].default_value = texProperty.T.mask
+
+
+class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
+    bl_idname = "material.hm64_apply_reference_size"
+    bl_label = "Apply Native Size to Reference"
+    bl_description = (
+        "Fill Texture Size and S/T tile bounds (mask/shift/low/high) from the Native Width/Height selection, "
+        "since Auto Set Other Properties doesn't track reference-mode textures"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    combinerTexIndex: bpy.props.IntProperty()
+
+    def execute(self, context):
+        material = context.material
+        texProp = getattr(material.f3d_mat, "tex" + str(self.combinerTexIndex))
+        if texProp.tex_format != "RGBA32":
+            self.report({"ERROR"}, "Set Format to RGBA32 first.")
+            return {"CANCELLED"}
+        native_size = getNativeSizeOverride(texProp)
+        if native_size is None:
+            self.report({"ERROR"}, "Set Native Width and Native Height first.")
+            return {"CANCELLED"}
+        texProp.tex_reference_size = native_size
+        setAutoProp(texProp.S, native_size[0])
+        setAutoProp(texProp.T, native_size[1])
+        self.report({"INFO"}, f"Set Texture Size and S/T bounds to {native_size}.")
+        return {"FINISHED"}
 
 
 def _ui_dynamic_cosmetic_entry(self, f3dMat, layout, enabledProp, nameProp, categoryProp):
@@ -92,6 +163,17 @@ def _ui_image(
         row.prop(textureProp, "is_vanilla_texture", text="Is Vanilla Texture?")
         row = box.row(align=True)
         row.prop(textureProp, "texture_internal_path", text="Internal Path")
+        if is_hm64_feature_set() and textureProp.tex_format == "RGBA32":
+            row = box.row(align=True)
+            row.prop(textureProp, "hd_native_width", text="Native Width")
+            row.prop(textureProp, "hd_native_height", text="Native Height")
+    elif is_hm64_feature_set() and textureProp.tex_format == "RGBA32":
+        row = box.row(align=True)
+        row.prop(textureProp, "hd_native_width", text="Native Width")
+        row.prop(textureProp, "hd_native_height", text="Native Height")
+        row = box.row(align=True)
+        applyOp = row.operator(HM64_OT_ApplyReferenceSize.bl_idname, text="Apply to Texture Size")
+        applyOp.combinerTexIndex = int(name[-1]) if name and name[-1].isdigit() else 0
 
 
 def _texture_to_dict(self):
@@ -147,7 +229,10 @@ def _n64_colors_from_dict(self, data: dict):
 
 
 def register():
+    register_class(HM64_OT_ApplyReferenceSize)
+
     _ORIGINALS["ui_image"] = base.ui_image
+    _ORIGINALS["update_tex_values_field"] = base.update_tex_values_field
     _ORIGINALS["TextureProperty.to_dict"] = TextureProperty.to_dict
     _ORIGINALS["TextureProperty.from_dict"] = TextureProperty.from_dict
     _ORIGINALS["F3DMaterialProperty.n64_colors_to_dict"] = F3DMaterialProperty.n64_colors_to_dict
@@ -157,6 +242,7 @@ def register():
     F3DPanel.ui_prim = _ui_prim
     F3DPanel.ui_env = _ui_env
     base.ui_image = _ui_image
+    base.update_tex_values_field = _update_tex_values_field
     TextureProperty.to_dict = _texture_to_dict
     TextureProperty.from_dict = _texture_from_dict
     F3DMaterialProperty.n64_colors_to_dict = _n64_colors_to_dict
@@ -184,6 +270,18 @@ def register():
         description="Override the TLUT name used when exporting CI textures",
         default="",
     )
+    TextureProperty.hd_native_width = bpy.props.EnumProperty(
+        items=_HD_NATIVE_SIZE_ITEMS,
+        name="Native Width",
+        description="N64-native/TMEM width to spoof for this texture's addressing. Overrides TMEM-fit auto-divide.",
+        default="0",
+    )
+    TextureProperty.hd_native_height = bpy.props.EnumProperty(
+        items=_HD_NATIVE_SIZE_ITEMS,
+        name="Native Height",
+        description="N64-native/TMEM height to spoof for this texture's addressing. Overrides TMEM-fit auto-divide.",
+        default="0",
+    )
 
     F3DMaterialProperty.prim_dynamic_entry = bpy.props.BoolProperty(name="Dynamic Cosmetic Entry", default=False)
     F3DMaterialProperty.prim_dynamic_entry_name = bpy.props.StringProperty(name="Dynamic Cosmetic Entry Name")
@@ -194,14 +292,24 @@ def register():
 
 
 def unregister():
+    unregister_class(HM64_OT_ApplyReferenceSize)
+
     base.ui_image = _ORIGINALS["ui_image"]
+    base.update_tex_values_field = _ORIGINALS["update_tex_values_field"]
     TextureProperty.to_dict = _ORIGINALS["TextureProperty.to_dict"]
     TextureProperty.from_dict = _ORIGINALS["TextureProperty.from_dict"]
     F3DMaterialProperty.n64_colors_to_dict = _ORIGINALS["F3DMaterialProperty.n64_colors_to_dict"]
     F3DMaterialProperty.n64_colors_from_dict = _ORIGINALS["F3DMaterialProperty.n64_colors_from_dict"]
 
     for cls, names in {
-        TextureProperty: ("palette_color_count", "is_vanilla_texture", "texture_internal_path", "custom_palette_name"),
+        TextureProperty: (
+            "palette_color_count",
+            "is_vanilla_texture",
+            "texture_internal_path",
+            "custom_palette_name",
+            "hd_native_width",
+            "hd_native_height",
+        ),
         F3DMaterialProperty: (
             "prim_dynamic_entry",
             "prim_dynamic_entry_name",

--- a/fast64_internal/hm64/f3d/f3d_material_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_material_hm64.py
@@ -8,7 +8,7 @@ from ...f3d import f3d_material as base
 from ...f3d.f3d_material import F3DMaterialProperty, F3DPanel, TextureProperty, setAutoProp
 
 from ..utility import is_hm64
-from .f3d_texture_writer_hm64 import getNativeSizeOverride, resolveNativeSize
+from .f3d_texture_writer_hm64 import applyReferenceSize, getNativeSizeOverride, resolveNativeSize
 
 
 _ORIGINALS = {}
@@ -57,10 +57,7 @@ def _update_tex_values_field(self: Material, texProperty: TextureProperty, tex_s
 class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
     bl_idname = "material.hm64_apply_reference_size"
     bl_label = "Apply Native Size to Reference"
-    bl_description = (
-        "Fill Texture Size and S/T tile bounds (mask/shift/low/high) from the Native Width/Height selection, "
-        "since Auto Set Other Properties doesn't track reference-mode textures"
-    )
+    bl_description = "Fill Texture Size and S/T tile bounds (mask/shift/low/high) from the Native Width/Height selection"
     bl_options = {"REGISTER", "UNDO"}
 
     combinerTexIndex: bpy.props.IntProperty()
@@ -72,9 +69,7 @@ class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
         if native_size is None:
             self.report({"ERROR"}, "Set Native Width and Native Height first.")
             return {"CANCELLED"}
-        texProp.tex_reference_size = native_size
-        setAutoProp(texProp.S, native_size[0])
-        setAutoProp(texProp.T, native_size[1])
+        applyReferenceSize(texProp, native_size)
         self.report({"INFO"}, f"Set Texture Size and S/T bounds to {native_size}.")
         return {"FINISHED"}
 

--- a/fast64_internal/hm64/f3d/f3d_material_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_material_hm64.py
@@ -14,9 +14,9 @@ from .f3d_texture_writer_hm64 import applyReferenceSize, getNativeSizeOverride, 
 _ORIGINALS = {}
 
 _HD_NATIVE_SIZES = (4, 8, 16, 32, 64, 128, 256)
-_HD_NATIVE_SIZE_ITEMS = [("0", "Auto (TMEM-fit)", "Divide down to fit the TMEM budget; may not match the original asset's true resolution")] + [
-    (str(v), str(v), f"{v} texels") for v in _HD_NATIVE_SIZES
-]
+_HD_NATIVE_SIZE_ITEMS = [
+    ("0", "Auto (TMEM-fit)", "Divide down to fit the TMEM budget; may not match the original asset's true resolution")
+] + [(str(v), str(v), f"{v} texels") for v in _HD_NATIVE_SIZES]
 
 
 def is_hm64_feature_set() -> bool:
@@ -63,7 +63,9 @@ def _update_tex_values_field(self: Material, texProperty: TextureProperty, tex_s
 class HM64_OT_ApplyReferenceSize(bpy.types.Operator):
     bl_idname = "material.hm64_apply_reference_size"
     bl_label = "Apply Native Size to Reference"
-    bl_description = "Fill Texture Size and S/T tile bounds (mask/shift/low/high) from the Native Width/Height selection"
+    bl_description = (
+        "Fill Texture Size and S/T tile bounds (mask/shift/low/high) from the Native Width/Height selection"
+    )
     bl_options = {"REGISTER", "UNDO"}
 
     combinerTexIndex: bpy.props.IntProperty()

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -73,9 +73,7 @@ def resolveAddressingSize(texProp: TextureProperty) -> Optional[tuple[int, int]]
     return resolveNativeSize(texProp, (texProp.tex.size[0], texProp.tex.size[1]))
 
 
-def resolveHdScale(
-    real_size: tuple[int, int], native_size: tuple[int, int], native_format: str
-) -> tuple[float, float]:
+def resolveHdScale(real_size: tuple[int, int], native_size: tuple[int, int], native_format: str) -> tuple[float, float]:
     """H/V scale from native_size to real_size. H includes the bpp ratio between the
     RGBA32 raw payload and native_format."""
     bpp_ratio = 32 / base.texBitSizeInt[native_format]

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -49,6 +49,25 @@ def computeAutoNativeSize(tex_size: tuple[int, int], texFormat: str) -> tuple[in
         divisor *= 2
 
 
+def writeRawTextureData(image: bpy.types.Image, fImage: FImage):
+    """Write plain 4-bytes-per-texel RGBA8 pixel data (TEX_FLAG_LOAD_AS_RAW), not N64 bit-packed."""
+    width, height = image.size[0], image.size[1]
+    pixels = image.pixels[:]
+    channels = image.channels
+    data = bytearray(width * height * 4)
+    i = 0
+    for y in reversed(range(height)):
+        row = y * width
+        for x in range(width):
+            idx = (row + x) * channels
+            data[i] = int(round(pixels[idx + 0] * 0xFF)) & 0xFF
+            data[i + 1] = int(round(pixels[idx + 1] * 0xFF)) & 0xFF if channels > 1 else data[i]
+            data[i + 2] = int(round(pixels[idx + 2] * 0xFF)) & 0xFF if channels > 2 else data[i]
+            data[i + 3] = int(round(pixels[idx + 3] * 0xFF)) & 0xFF if channels > 3 else 0xFF
+            i += 4
+    fImage.data = bytes(data)
+
+
 class HM64PaletteKey(FPaletteKey):
     def __init__(self, palFormat: str, paletteName: str | None = None):
         self.palFormat = palFormat
@@ -202,6 +221,14 @@ def saveOrGetTextureDefinition(
         fImage.internal_path = sanitize_internal_asset_path(texProp.texture_internal_path)
     if texProp:
         fImage.skip_export = getattr(texProp, "is_vanilla_texture", False)
+    if texProp and not texProp.use_tex_reference and texProp.tex is not None and texProp.tex_format[:2] != "CI":
+        tex_size = tuple(texProp.tex.size)
+        native_size = computeAutoNativeSize(tex_size, texProp.tex_format)
+        if native_size != tex_size:
+            fImage.hd_width, fImage.hd_height = tex_size
+            fImage.hd_byte_scale = tex_size[0] / native_size[0]
+            fImage.hd_pixel_scale = tex_size[1] / native_size[1]
+            fImage.width, fImage.height = native_size
     return imageKey, fImage
 
 
@@ -341,13 +368,13 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
                         base.writePaletteData(fPalette, self.pal)
                     base.writeCITextureData(self.texProp.tex, fImage, self.pal, self.palFormat, self.texFormat)
             else:
-                tex = self.texProp.tex
-                base.writeNonCITextureData(tex, fImage, self.texFormat)
-                native_size = computeAutoNativeSize(tuple(tex.size), self.texFormat)
-                if native_size != tuple(tex.size):
-                    fImage.hd_width, fImage.hd_height = tex.size[0], tex.size[1]
-                    fImage.hd_byte_scale = tex.size[0] / native_size[0]
-                    fImage.hd_pixel_scale = tex.size[1] / native_size[1]
+                isHd = (
+                    getattr(fImage, "hd_byte_scale", 1.0) != 1.0 or getattr(fImage, "hd_pixel_scale", 1.0) != 1.0
+                )
+                if isHd:
+                    writeRawTextureData(self.texProp.tex, fImage)
+                else:
+                    base.writeNonCITextureData(self.texProp.tex, fImage, self.texFormat)
 
 
 def saveTextureLoadOnly(

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -62,36 +62,48 @@ def resolveNativeSize(texProp: TextureProperty, real_size: tuple[int, int]) -> t
     return getNativeSizeOverride(texProp) or computeAutoNativeSize(real_size, texProp.tex_format)
 
 
+def resolveAddressingSize(texProp: TextureProperty) -> Optional[tuple[int, int]]:
+    """Returns the size used to address texProp in the display list: tex_reference_size for
+    reference-mode, else the native/TMEM-fit size resolved from its assigned image. Returns
+    None when texProp has no reference size and no image assigned."""
+    if texProp.use_tex_reference:
+        return tuple(texProp.tex_reference_size)
+    if texProp.tex is None:
+        return None
+    return resolveNativeSize(texProp, (texProp.tex.size[0], texProp.tex.size[1]))
+
+
 def resolveHdScale(
     real_size: tuple[int, int], native_size: tuple[int, int], native_format: str
 ) -> tuple[float, float]:
-    """H/V scale from native_size to real_size. H also folds in the bpp ratio between the
-    always-RGBA32 raw payload and native_format, since the DL may declare any format."""
+    """H/V scale from native_size to real_size. H includes the bpp ratio between the
+    RGBA32 raw payload and native_format."""
     bpp_ratio = 32 / base.texBitSizeInt[native_format]
     return (real_size[0] / native_size[0]) * bpp_ratio, real_size[1] / native_size[1]
 
 
+def applyReferenceSize(texProp: TextureProperty, size: tuple[int, int]) -> None:
+    """Set tex_reference_size and the S/T tile bounds (mask/shift/low/high) to size."""
+    texProp.tex_reference_size = size
+    setAutoProp(texProp.S, size[0])
+    setAutoProp(texProp.T, size[1])
+
+
 def syncAutoReferenceSize(texProp: TextureProperty, real_size: tuple[int, int]) -> None:
-    """Keep a reference-mode (flipbook) texture slot's tex_reference_size, and its S/T tile
-    bounds, in sync with the current format's TMEM-fit auto size, computed from real_size (an
-    actual backing image's real dimensions). Auto Set Other Properties doesn't track
-    reference-mode textures, so nothing else keeps this in sync across a format change.
-    No-op when the artist has a manual native-size override set (Native Width/Height)."""
+    """Set tex_reference_size and S/T tile bounds to the current format's TMEM-fit auto size
+    computed from real_size. No-op when a manual native-size override (Native Width/Height)
+    is set, or when tex_reference_size already matches the auto size."""
     if getNativeSizeOverride(texProp) is not None:
         return
     auto_size = computeAutoNativeSize(real_size, texProp.tex_format)
     if tuple(texProp.tex_reference_size) == auto_size:
         return
-    texProp.tex_reference_size = auto_size
-    setAutoProp(texProp.S, auto_size[0])
-    setAutoProp(texProp.T, auto_size[1])
+    applyReferenceSize(texProp, auto_size)
 
 
 def syncMaterialReferenceSizes(material: bpy.types.Material) -> None:
     """Call syncAutoReferenceSize for every flipbook-backed reference-mode texture slot on a
-    material. Idempotent and safe to call from multiple points in the export pipeline (mesh UV
-    preprocessing, scroll-dimension calc, DL generation) since each reads tex_reference_size
-    independently and none of them share a guaranteed call order."""
+    material, using the flipbook's first assigned image as the real size."""
     f3dMat = material.f3d_mat
     for index in range(2):
         texProp = getattr(f3dMat, f"tex{index}")
@@ -418,11 +430,7 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
         else:
             if self.isTexCI:
                 assert self.pal is not None
-                if isHdFImage(fImage):
-                    if self.loadPal and not self.isPalRef:
-                        base.writePaletteData(fPalette, self.pal)
-                    writeRawTextureData(self.texProp.tex, fImage)
-                elif shared_tlut_state is not None:
+                if shared_tlut_state is not None and not isHdFImage(fImage):
                     shared_tlut_state.texture_uses[self.texProp.tex] = (
                         self.texProp.tex,
                         fImage,
@@ -433,7 +441,10 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
                 else:
                     if self.loadPal and not self.isPalRef:
                         base.writePaletteData(fPalette, self.pal)
-                    base.writeCITextureData(self.texProp.tex, fImage, self.pal, self.palFormat, self.texFormat)
+                    if isHdFImage(fImage):
+                        writeRawTextureData(self.texProp.tex, fImage)
+                    else:
+                        base.writeCITextureData(self.texProp.tex, fImage, self.pal, self.palFormat, self.texFormat)
             else:
                 if isHdFImage(fImage):
                     writeRawTextureData(self.texProp.tex, fImage)

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -56,17 +56,18 @@ def getNativeSizeOverride(texProp: TextureProperty) -> Optional[tuple[int, int]]
     return (w, h) if w and h else None
 
 
-HD_EXPORT_FORMAT = "RGBA32"
-
-
 def resolveNativeSize(texProp: TextureProperty, real_size: tuple[int, int]) -> tuple[int, int]:
     """Native/TMEM size to spoof to: artist override, else auto-computed TMEM fit."""
     return getNativeSizeOverride(texProp) or computeAutoNativeSize(real_size, texProp.tex_format)
 
 
-def resolveHdScale(real_size: tuple[int, int], native_size: tuple[int, int]) -> tuple[float, float]:
-    """H/V scale from native_size to real_size."""
-    return real_size[0] / native_size[0], real_size[1] / native_size[1]
+def resolveHdScale(
+    real_size: tuple[int, int], native_size: tuple[int, int], native_format: str
+) -> tuple[float, float]:
+    """H/V scale from native_size to real_size. H also folds in the bpp ratio between the
+    always-RGBA32 raw payload and native_format, since the DL may declare any format."""
+    bpp_ratio = 32 / base.texBitSizeInt[native_format]
+    return (real_size[0] / native_size[0]) * bpp_ratio, real_size[1] / native_size[1]
 
 
 def isHdFImage(fImage: FImage) -> bool:
@@ -246,13 +247,14 @@ def saveOrGetTextureDefinition(
         fImage.internal_path = sanitize_internal_asset_path(texProp.texture_internal_path)
     if texProp:
         fImage.skip_export = getattr(texProp, "is_vanilla_texture", False)
-    if texProp and not texProp.use_tex_reference and texProp.tex is not None and texProp.tex_format == HD_EXPORT_FORMAT:
+    if texProp and not texProp.use_tex_reference and texProp.tex is not None:
         # Spoof FImage's own size down to native/TMEM-legal; real HD size + scale go on the side.
+        # Format-agnostic: works for any declared format, not just RGBA32.
         tex_size = tuple(texProp.tex.size)
         native_size = resolveNativeSize(texProp, tex_size)
         if native_size != tex_size:
             fImage.hd_width, fImage.hd_height = tex_size
-            fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(tex_size, native_size)
+            fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(tex_size, native_size, texProp.tex_format)
             fImage.width, fImage.height = native_size
     return imageKey, fImage
 
@@ -287,10 +289,9 @@ def fromProp(self, texProp: TextureProperty, index: int, ignore_tex_set=False) -
 
     if self.isTexRef:
         width, height = texProp.tex_reference_size
-    elif self.texFormat != HD_EXPORT_FORMAT:
-        width, height = tex.size
     else:
         # Spoof the TMEM/tile size against the native size, not the real HD image size.
+        # A no-op (returns tex.size unchanged) when the image already fits TMEM at its real size.
         width, height = resolveNativeSize(texProp, tuple(tex.size))
     self.imageDims = (width, height)
 
@@ -381,7 +382,11 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
         else:
             if self.isTexCI:
                 assert self.pal is not None
-                if shared_tlut_state is not None:
+                if isHdFImage(fImage):
+                    if self.loadPal and not self.isPalRef:
+                        base.writePaletteData(fPalette, self.pal)
+                    writeRawTextureData(self.texProp.tex, fImage)
+                elif shared_tlut_state is not None:
                     shared_tlut_state.texture_uses[self.texProp.tex] = (
                         self.texProp.tex,
                         fImage,

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -21,13 +21,32 @@ from ...f3d.f3d_gbi import (
     FTexRect,
     GfxList,
 )
-from ...f3d.f3d_material import F3DMaterialProperty, TextureProperty, texBitSizeF3D, texFormatOf
+from ...f3d.f3d_material import (
+    F3DMaterialProperty,
+    TextureProperty,
+    getTmemMax,
+    getTmemWordUsage,
+    texBitSizeF3D,
+    texFormatOf,
+)
 from ...utility import PluginError, toAlnum
 from ..utility import is_hm64, sanitize_internal_asset_path
 
 
 _ORIGINALS = {}
 _REGISTERED = False
+
+
+def computeAutoNativeSize(tex_size: tuple[int, int], texFormat: str) -> tuple[int, int]:
+    """Divide an image's size by powers of two until it fits texFormat's TMEM budget."""
+    width, height = tex_size
+    tmemWordBudget = getTmemMax(texFormat) // 8  # bytes -> words, same unit as getTmemWordUsage
+    divisor = 1
+    while True:
+        w, h = max(1, width // divisor), max(1, height // divisor)
+        if getTmemWordUsage(texFormat, w, h) <= tmemWordBudget or (w == 1 and h == 1):
+            return (w, h)
+        divisor *= 2
 
 
 class HM64PaletteKey(FPaletteKey):
@@ -186,6 +205,55 @@ def saveOrGetTextureDefinition(
     return imageKey, fImage
 
 
+def fromProp(self, texProp: TextureProperty, index: int, ignore_tex_set=False) -> bool:
+    if not is_hm64():
+        return _ORIGINALS["TexInfo.fromProp"](self, texProp, index, ignore_tex_set)
+
+    self.indexInMat = index
+    self.texProp = texProp
+    if not texProp.tex_set and not ignore_tex_set:
+        return True
+
+    self.useTex = True
+    tex = texProp.tex
+    self.isTexRef = texProp.use_tex_reference
+    self.texFormat = texProp.tex_format
+    self.isTexCI = self.texFormat[:2] == "CI"
+    self.palFormat = texProp.ci_format if self.isTexCI else ""
+
+    if tex is not None and (tex.size[0] == 0 or tex.size[1] == 0):
+        self.errorMsg = f"Image {tex.name} has 0 size; may have been deleted/moved."
+        return False
+
+    if not self.isTexRef:
+        if tex is None:
+            self.errorMsg = "No texture is selected."
+            return False
+        elif len(tex.pixels) == 0:
+            self.errorMsg = f"Image {tex.name} is missing on disk."
+            return False
+
+    if self.isTexRef:
+        width, height = texProp.tex_reference_size
+    elif self.isTexCI:
+        width, height = tex.size
+    else:
+        width, height = computeAutoNativeSize(tuple(tex.size), self.texFormat)
+    self.imageDims = (width, height)
+
+    self.tmemSize = base.getTmemWordUsage(self.texFormat, width, height)
+
+    if width > 1024 or height > 1024:
+        self.errorMsg = "Image size (even large textures) limited to 1024 in each dimension."
+        return False
+
+    if base.texBitSizeInt[self.texFormat] == 4 and (width & 1) != 0:
+        self.errorMsg = "A 4-bit image must have a width which is even."
+        return False
+
+    return True
+
+
 def getPaletteName(self):
     if not is_hm64():
         return _ORIGINALS["TexInfo.getPaletteName"](self)
@@ -273,7 +341,13 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
                         base.writePaletteData(fPalette, self.pal)
                     base.writeCITextureData(self.texProp.tex, fImage, self.pal, self.palFormat, self.texFormat)
             else:
-                base.writeNonCITextureData(self.texProp.tex, fImage, self.texFormat)
+                tex = self.texProp.tex
+                base.writeNonCITextureData(tex, fImage, self.texFormat)
+                native_size = computeAutoNativeSize(tuple(tex.size), self.texFormat)
+                if native_size != tuple(tex.size):
+                    fImage.hd_width, fImage.hd_height = tex.size[0], tex.size[1]
+                    fImage.hd_byte_scale = tex.size[0] / native_size[0]
+                    fImage.hd_pixel_scale = tex.size[1] / native_size[1]
 
 
 def saveTextureLoadOnly(
@@ -444,6 +518,7 @@ def register():
     _ORIGINALS["saveTextureTile"] = base.saveTextureTile
     _ORIGINALS["TexInfo.getPaletteName"] = base.TexInfo.getPaletteName
     _ORIGINALS["TexInfo.writeAll"] = base.TexInfo.writeAll
+    _ORIGINALS["TexInfo.fromProp"] = base.TexInfo.fromProp
     base.getTextureNamesFromBasename = getTextureNamesFromBasename
     base.saveOrGetPaletteDefinition = saveOrGetPaletteDefinition
     base.saveOrGetTextureDefinition = saveOrGetTextureDefinition
@@ -452,6 +527,7 @@ def register():
     base.saveTextureTile = saveTextureTile
     base.TexInfo.getPaletteName = getPaletteName
     base.TexInfo.writeAll = writeAll
+    base.TexInfo.fromProp = fromProp
     base.TexInfo.custom_palette_requested = False
     _REGISTERED = True
 
@@ -469,4 +545,5 @@ def unregister():
     base.saveTextureTile = _ORIGINALS["saveTextureTile"]
     base.TexInfo.getPaletteName = _ORIGINALS["TexInfo.getPaletteName"]
     base.TexInfo.writeAll = _ORIGINALS["TexInfo.writeAll"]
+    base.TexInfo.fromProp = _ORIGINALS["TexInfo.fromProp"]
     _REGISTERED = False

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -49,6 +49,31 @@ def computeAutoNativeSize(tex_size: tuple[int, int], texFormat: str) -> tuple[in
         divisor *= 2
 
 
+def getNativeSizeOverride(texProp: TextureProperty) -> Optional[tuple[int, int]]:
+    """Returns the artist-selected native size (Native Width/Height dropdowns), or None if unset."""
+    w = int(getattr(texProp, "hd_native_width", "0"))
+    h = int(getattr(texProp, "hd_native_height", "0"))
+    return (w, h) if w and h else None
+
+
+HD_EXPORT_FORMAT = "RGBA32"
+
+
+def resolveNativeSize(texProp: TextureProperty, real_size: tuple[int, int]) -> tuple[int, int]:
+    """Native/TMEM size to spoof to: artist override, else auto-computed TMEM fit."""
+    return getNativeSizeOverride(texProp) or computeAutoNativeSize(real_size, texProp.tex_format)
+
+
+def resolveHdScale(real_size: tuple[int, int], native_size: tuple[int, int]) -> tuple[float, float]:
+    """H/V scale from native_size to real_size."""
+    return real_size[0] / native_size[0], real_size[1] / native_size[1]
+
+
+def isHdFImage(fImage: FImage) -> bool:
+    """True when an FImage's addressing was spoofed to a smaller native size than its real content."""
+    return getattr(fImage, "hd_byte_scale", 1.0) != 1.0 or getattr(fImage, "hd_pixel_scale", 1.0) != 1.0
+
+
 def writeRawTextureData(image: bpy.types.Image, fImage: FImage):
     """Write plain 4-bytes-per-texel RGBA8 pixel data (TEX_FLAG_LOAD_AS_RAW), not N64 bit-packed."""
     width, height = image.size[0], image.size[1]
@@ -221,13 +246,13 @@ def saveOrGetTextureDefinition(
         fImage.internal_path = sanitize_internal_asset_path(texProp.texture_internal_path)
     if texProp:
         fImage.skip_export = getattr(texProp, "is_vanilla_texture", False)
-    if texProp and not texProp.use_tex_reference and texProp.tex is not None and texProp.tex_format[:2] != "CI":
+    if texProp and not texProp.use_tex_reference and texProp.tex is not None and texProp.tex_format == HD_EXPORT_FORMAT:
+        # Spoof FImage's own size down to native/TMEM-legal; real HD size + scale go on the side.
         tex_size = tuple(texProp.tex.size)
-        native_size = computeAutoNativeSize(tex_size, texProp.tex_format)
+        native_size = resolveNativeSize(texProp, tex_size)
         if native_size != tex_size:
             fImage.hd_width, fImage.hd_height = tex_size
-            fImage.hd_byte_scale = tex_size[0] / native_size[0]
-            fImage.hd_pixel_scale = tex_size[1] / native_size[1]
+            fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(tex_size, native_size)
             fImage.width, fImage.height = native_size
     return imageKey, fImage
 
@@ -262,10 +287,11 @@ def fromProp(self, texProp: TextureProperty, index: int, ignore_tex_set=False) -
 
     if self.isTexRef:
         width, height = texProp.tex_reference_size
-    elif self.isTexCI:
+    elif self.texFormat != HD_EXPORT_FORMAT:
         width, height = tex.size
     else:
-        width, height = computeAutoNativeSize(tuple(tex.size), self.texFormat)
+        # Spoof the TMEM/tile size against the native size, not the real HD image size.
+        width, height = resolveNativeSize(texProp, tuple(tex.size))
     self.imageDims = (width, height)
 
     self.tmemSize = base.getTmemWordUsage(self.texFormat, width, height)
@@ -368,10 +394,7 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
                         base.writePaletteData(fPalette, self.pal)
                     base.writeCITextureData(self.texProp.tex, fImage, self.pal, self.palFormat, self.texFormat)
             else:
-                isHd = (
-                    getattr(fImage, "hd_byte_scale", 1.0) != 1.0 or getattr(fImage, "hd_pixel_scale", 1.0) != 1.0
-                )
-                if isHd:
+                if isHdFImage(fImage):
                     writeRawTextureData(self.texProp.tex, fImage)
                 else:
                     base.writeNonCITextureData(self.texProp.tex, fImage, self.texFormat)

--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -26,6 +26,7 @@ from ...f3d.f3d_material import (
     TextureProperty,
     getTmemMax,
     getTmemWordUsage,
+    setAutoProp,
     texBitSizeF3D,
     texFormatOf,
 )
@@ -68,6 +69,41 @@ def resolveHdScale(
     always-RGBA32 raw payload and native_format, since the DL may declare any format."""
     bpp_ratio = 32 / base.texBitSizeInt[native_format]
     return (real_size[0] / native_size[0]) * bpp_ratio, real_size[1] / native_size[1]
+
+
+def syncAutoReferenceSize(texProp: TextureProperty, real_size: tuple[int, int]) -> None:
+    """Keep a reference-mode (flipbook) texture slot's tex_reference_size, and its S/T tile
+    bounds, in sync with the current format's TMEM-fit auto size, computed from real_size (an
+    actual backing image's real dimensions). Auto Set Other Properties doesn't track
+    reference-mode textures, so nothing else keeps this in sync across a format change.
+    No-op when the artist has a manual native-size override set (Native Width/Height)."""
+    if getNativeSizeOverride(texProp) is not None:
+        return
+    auto_size = computeAutoNativeSize(real_size, texProp.tex_format)
+    if tuple(texProp.tex_reference_size) == auto_size:
+        return
+    texProp.tex_reference_size = auto_size
+    setAutoProp(texProp.S, auto_size[0])
+    setAutoProp(texProp.T, auto_size[1])
+
+
+def syncMaterialReferenceSizes(material: bpy.types.Material) -> None:
+    """Call syncAutoReferenceSize for every flipbook-backed reference-mode texture slot on a
+    material. Idempotent and safe to call from multiple points in the export pipeline (mesh UV
+    preprocessing, scroll-dimension calc, DL generation) since each reads tex_reference_size
+    independently and none of them share a guaranteed call order."""
+    f3dMat = material.f3d_mat
+    for index in range(2):
+        texProp = getattr(f3dMat, f"tex{index}")
+        if not texProp.use_tex_reference:
+            continue
+        flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}", None)
+        if flipbookProp is None:
+            continue
+        first_image = next((t.image for t in flipbookProp.textures if t.image is not None), None)
+        if first_image is None:
+            continue
+        syncAutoReferenceSize(texProp, tuple(first_image.size))
 
 
 def isHdFImage(fImage: FImage) -> bool:

--- a/fast64_internal/hm64/f3d/hm64_f3d_writer.py
+++ b/fast64_internal/hm64/f3d/hm64_f3d_writer.py
@@ -1269,19 +1269,19 @@ def getTexDimensions(material):
     def addressing_dimensions(tex_prop):
         """Return the logical dimensions encoded into the N64 display list.
 
-        HD RGBA32 resources retain their real dimensions in the texture resource,
-        but vertices, masks, clamp bounds, mirror periods, and scroll values must
-        all remain in the spoofed native texel space.  This matches Retro's
-        replacement workflow, where the original display list is left unchanged.
+        HD resources (any format) retain their real dimensions in the texture
+        resource, but vertices, masks, clamp bounds, mirror periods, and scroll
+        values must all remain in the spoofed native texel space.  This matches
+        Retro's replacement workflow, where the original display list is left
+        unchanged.  resolveNativeSize is a no-op when the image already fits
+        TMEM at its real size, so this is safe to call unconditionally.
         """
         if tex_prop.use_tex_reference:
             return tuple(tex_prop.tex_reference_size)
         if tex_prop.tex is None:
             raise PluginError(f'In material "{material.name}", a texture has not been set.')
         real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
-        if tex_prop.tex_format == "RGBA32":
-            return resolveNativeSize(tex_prop, real_size)
-        return real_size
+        return resolveNativeSize(tex_prop, real_size)
 
     texDimensions0 = None
     texDimensions1 = None
@@ -1315,9 +1315,7 @@ def getHM64MaterialScrollDimensions(f3dMat):
             tex_dims = tuple(tex_prop.tex_reference_size)
         elif tex_prop.tex is not None:
             real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
-            tex_dims = (
-                resolveNativeSize(tex_prop, real_size) if tex_prop.tex_format == "RGBA32" else real_size
-            )
+            tex_dims = resolveNativeSize(tex_prop, real_size)
         else:
             tex_dims = (1, 1)
         dimensions.append(shift_dimensions(tex_prop, tex_dims))

--- a/fast64_internal/hm64/f3d/hm64_f3d_writer.py
+++ b/fast64_internal/hm64/f3d/hm64_f3d_writer.py
@@ -9,15 +9,16 @@ from bpy.utils import register_class, unregister_class
 from ...f3d.f3d_enums import *
 from ...f3d.f3d_material import (
     all_combiner_uses,
-    getMaterialScrollDimensions,
     isTexturePointSampled,
     get_textlut_mode,
     RDPSettings,
+    shift_dimensions,
 )
 from ...f3d.f3d_texture_writer import MultitexManager, TileLoad, maybeSaveSingleLargeTextureSetup
 from ...f3d.f3d_gbi import *
 from ..f3d.f3d_gbi_hm64 import make_env_color, make_prim_color
 from ..f3d.f3d_material_hm64 import is_hm64_feature_set
+from ..f3d.f3d_texture_writer_hm64 import resolveNativeSize
 from ..f3d.hm64_bleed import get_geo_cmds
 from ...f3d.f3d_writer import (
     exportF3DtoC as shared_exportF3DtoC,
@@ -1265,23 +1266,30 @@ defaultLighting = [
 def getTexDimensions(material):
     f3dMat = material.f3d_mat
 
+    def addressing_dimensions(tex_prop):
+        """Return the logical dimensions encoded into the N64 display list.
+
+        HD RGBA32 resources retain their real dimensions in the texture resource,
+        but vertices, masks, clamp bounds, mirror periods, and scroll values must
+        all remain in the spoofed native texel space.  This matches Retro's
+        replacement workflow, where the original display list is left unchanged.
+        """
+        if tex_prop.use_tex_reference:
+            return tuple(tex_prop.tex_reference_size)
+        if tex_prop.tex is None:
+            raise PluginError(f'In material "{material.name}", a texture has not been set.')
+        real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
+        if tex_prop.tex_format == "RGBA32":
+            return resolveNativeSize(tex_prop, real_size)
+        return real_size
+
     texDimensions0 = None
     texDimensions1 = None
     useDict = all_combiner_uses(f3dMat)
     if useDict["Texture 0"] and f3dMat.tex0.tex_set:
-        if f3dMat.tex0.use_tex_reference:
-            texDimensions0 = f3dMat.tex0.tex_reference_size
-        else:
-            if f3dMat.tex0.tex is None:
-                raise PluginError('In material "' + material.name + '", a texture has not been set.')
-            texDimensions0 = f3dMat.tex0.tex.size[0], f3dMat.tex0.tex.size[1]
+        texDimensions0 = addressing_dimensions(f3dMat.tex0)
     if useDict["Texture 1"] and f3dMat.tex1.tex_set:
-        if f3dMat.tex1.use_tex_reference:
-            texDimensions1 = f3dMat.tex1.tex_reference_size
-        else:
-            if f3dMat.tex1.tex is None:
-                raise PluginError('In material "' + material.name + '", a texture has not been set.')
-            texDimensions1 = f3dMat.tex1.tex.size[0], f3dMat.tex1.tex.size[1]
+        texDimensions1 = addressing_dimensions(f3dMat.tex1)
 
     if texDimensions0 is not None and texDimensions1 is not None:
         texDimensions = texDimensions0 if f3dMat.uv_basis == "TEXEL0" else texDimensions1
@@ -1292,6 +1300,28 @@ def getTexDimensions(material):
     else:
         texDimensions = [32, 32]
     return texDimensions
+
+
+def getHM64MaterialScrollDimensions(f3dMat):
+    """Native-space counterpart of f3d_material.getMaterialScrollDimensions."""
+    dimensions = []
+    useDict = all_combiner_uses(f3dMat)
+    for index in range(2):
+        tex_prop = getattr(f3dMat, f"tex{index}")
+        if not useDict[f"Texture {index}"] or not tex_prop.tex_set:
+            dimensions.append((1, 1))
+            continue
+        if tex_prop.use_tex_reference:
+            tex_dims = tuple(tex_prop.tex_reference_size)
+        elif tex_prop.tex is not None:
+            real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
+            tex_dims = (
+                resolveNativeSize(tex_prop, real_size) if tex_prop.tex_format == "RGBA32" else real_size
+            )
+        else:
+            tex_dims = (1, 1)
+        dimensions.append(shift_dimensions(tex_prop, tex_dims))
+    return (max(1, dimensions[0][0], dimensions[1][0]), max(1, dimensions[0][1], dimensions[1][1]))
 
 
 @wrap_func_with_error_message(lambda args: (f"In material '{args['material'].name}': "))
@@ -1347,7 +1377,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     if fMaterial.revert is not None:
         fMaterial.revert.commands.append(DPPipeSync())
 
-    fMaterial.getScrollData(material, getMaterialScrollDimensions(f3dMat))
+    fMaterial.getScrollData(material, getHM64MaterialScrollDimensions(f3dMat))
 
     if f3dMat.set_combiner:
         if f3dMat.rdp_settings.g_mdsft_cycletype == "G_CYC_2CYCLE":

--- a/fast64_internal/hm64/f3d/hm64_f3d_writer.py
+++ b/fast64_internal/hm64/f3d/hm64_f3d_writer.py
@@ -18,7 +18,7 @@ from ...f3d.f3d_texture_writer import MultitexManager, TileLoad, maybeSaveSingle
 from ...f3d.f3d_gbi import *
 from ..f3d.f3d_gbi_hm64 import make_env_color, make_prim_color
 from ..f3d.f3d_material_hm64 import is_hm64_feature_set
-from ..f3d.f3d_texture_writer_hm64 import resolveNativeSize, syncMaterialReferenceSizes
+from ..f3d.f3d_texture_writer_hm64 import resolveAddressingSize, syncMaterialReferenceSizes
 from ..f3d.hm64_bleed import get_geo_cmds
 from ...f3d.f3d_writer import (
     exportF3DtoC as shared_exportF3DtoC,
@@ -1268,21 +1268,11 @@ def getTexDimensions(material):
     syncMaterialReferenceSizes(material)
 
     def addressing_dimensions(tex_prop):
-        """Return the logical dimensions encoded into the N64 display list.
-
-        HD resources (any format) retain their real dimensions in the texture
-        resource, but vertices, masks, clamp bounds, mirror periods, and scroll
-        values must all remain in the spoofed native texel space.  This matches
-        Retro's replacement workflow, where the original display list is left
-        unchanged.  resolveNativeSize is a no-op when the image already fits
-        TMEM at its real size, so this is safe to call unconditionally.
-        """
-        if tex_prop.use_tex_reference:
-            return tuple(tex_prop.tex_reference_size)
-        if tex_prop.tex is None:
+        """Return the logical dimensions encoded into the N64 display list."""
+        size = resolveAddressingSize(tex_prop)
+        if size is None:
             raise PluginError(f'In material "{material.name}", a texture has not been set.')
-        real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
-        return resolveNativeSize(tex_prop, real_size)
+        return size
 
     texDimensions0 = None
     texDimensions1 = None
@@ -1312,13 +1302,7 @@ def getHM64MaterialScrollDimensions(f3dMat):
         if not useDict[f"Texture {index}"] or not tex_prop.tex_set:
             dimensions.append((1, 1))
             continue
-        if tex_prop.use_tex_reference:
-            tex_dims = tuple(tex_prop.tex_reference_size)
-        elif tex_prop.tex is not None:
-            real_size = (tex_prop.tex.size[0], tex_prop.tex.size[1])
-            tex_dims = resolveNativeSize(tex_prop, real_size)
-        else:
-            tex_dims = (1, 1)
+        tex_dims = resolveAddressingSize(tex_prop) or (1, 1)
         dimensions.append(shift_dimensions(tex_prop, tex_dims))
     return (max(1, dimensions[0][0], dimensions[1][0]), max(1, dimensions[0][1], dimensions[1][1]))
 

--- a/fast64_internal/hm64/f3d/hm64_f3d_writer.py
+++ b/fast64_internal/hm64/f3d/hm64_f3d_writer.py
@@ -18,7 +18,7 @@ from ...f3d.f3d_texture_writer import MultitexManager, TileLoad, maybeSaveSingle
 from ...f3d.f3d_gbi import *
 from ..f3d.f3d_gbi_hm64 import make_env_color, make_prim_color
 from ..f3d.f3d_material_hm64 import is_hm64_feature_set
-from ..f3d.f3d_texture_writer_hm64 import resolveNativeSize
+from ..f3d.f3d_texture_writer_hm64 import resolveNativeSize, syncMaterialReferenceSizes
 from ..f3d.hm64_bleed import get_geo_cmds
 from ...f3d.f3d_writer import (
     exportF3DtoC as shared_exportF3DtoC,
@@ -1265,6 +1265,7 @@ defaultLighting = [
 
 def getTexDimensions(material):
     f3dMat = material.f3d_mat
+    syncMaterialReferenceSizes(material)
 
     def addressing_dimensions(tex_prop):
         """Return the logical dimensions encoded into the N64 display list.
@@ -1329,6 +1330,8 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         f3dMat = material.f3d_mat
     else:
         f3dMat = material
+
+    syncMaterialReferenceSizes(material)
 
     areaKey = fModel.global_data.getCurrentAreaKey(f3dMat)
     areaIndex = fModel.global_data.current_area_index

--- a/fast64_internal/hm64/f3d/soh_xml_exporter.py
+++ b/fast64_internal/hm64/f3d/soh_xml_exporter.py
@@ -465,7 +465,12 @@ def _FModel_save_soh_textures(self, exportPath):
             h_byte_scale = getattr(texture, "hd_byte_scale", 1.0)
             v_pixel_scale = getattr(texture, "hd_pixel_scale", 1.0)
             TEX_FLAG_LOAD_AS_RAW = 1
-            flags = TEX_FLAG_LOAD_AS_RAW if (h_byte_scale != 1.0 or v_pixel_scale != 1.0) else 0
+            is_hd = h_byte_scale != 1.0 or v_pixel_scale != 1.0
+            if is_hd:
+                # Raw HD payload is always written as 4-byte RGBA32 texels, independent of
+                # whatever format the DL declares (matches the native-size-spoofed tile).
+                fmt_code = 1
+            flags = TEX_FLAG_LOAD_AS_RAW if is_hd else 0
             with open(targetPath, "wb") as file:
                 file.write(
                     pack(

--- a/fast64_internal/hm64/f3d/soh_xml_exporter.py
+++ b/fast64_internal/hm64/f3d/soh_xml_exporter.py
@@ -467,9 +467,7 @@ def _FModel_save_soh_textures(self, exportPath):
             TEX_FLAG_LOAD_AS_RAW = 1
             is_hd = h_byte_scale != 1.0 or v_pixel_scale != 1.0
             if is_hd:
-                # Raw HD payload is always written as 4-byte RGBA32 texels, independent of
-                # whatever format the DL declares (matches the native-size-spoofed tile).
-                fmt_code = 1
+                fmt_code = 1  # raw HD payload is always 4-byte RGBA32 texels
             flags = TEX_FLAG_LOAD_AS_RAW if is_hd else 0
             with open(targetPath, "wb") as file:
                 file.write(

--- a/fast64_internal/hm64/f3d/soh_xml_exporter.py
+++ b/fast64_internal/hm64/f3d/soh_xml_exporter.py
@@ -459,6 +459,7 @@ def _FModel_save_soh_textures(self, exportPath):
         oldpath = image.filepath
         try:
             image.filepath = targetPath
+            # Resource header carries the real HD size/scale/raw-tag; display list stays native.
             width = getattr(texture, "hd_width", texture.width)
             height = getattr(texture, "hd_height", texture.height)
             h_byte_scale = getattr(texture, "hd_byte_scale", 1.0)

--- a/fast64_internal/hm64/f3d/soh_xml_exporter.py
+++ b/fast64_internal/hm64/f3d/soh_xml_exporter.py
@@ -463,6 +463,8 @@ def _FModel_save_soh_textures(self, exportPath):
             height = getattr(texture, "hd_height", texture.height)
             h_byte_scale = getattr(texture, "hd_byte_scale", 1.0)
             v_pixel_scale = getattr(texture, "hd_pixel_scale", 1.0)
+            TEX_FLAG_LOAD_AS_RAW = 1
+            flags = TEX_FLAG_LOAD_AS_RAW if (h_byte_scale != 1.0 or v_pixel_scale != 1.0) else 0
             with open(targetPath, "wb") as file:
                 file.write(
                     pack(
@@ -481,7 +483,7 @@ def _FModel_save_soh_textures(self, exportPath):
                         fmt_code,
                         width,
                         height,
-                        0,
+                        flags,
                         h_byte_scale,
                         v_pixel_scale,
                         len(texture.data),

--- a/fast64_internal/hm64/f3d/soh_xml_exporter.py
+++ b/fast64_internal/hm64/f3d/soh_xml_exporter.py
@@ -459,6 +459,10 @@ def _FModel_save_soh_textures(self, exportPath):
         oldpath = image.filepath
         try:
             image.filepath = targetPath
+            width = getattr(texture, "hd_width", texture.width)
+            height = getattr(texture, "hd_height", texture.height)
+            h_byte_scale = getattr(texture, "hd_byte_scale", 1.0)
+            v_pixel_scale = getattr(texture, "hd_pixel_scale", 1.0)
             with open(targetPath, "wb") as file:
                 file.write(
                     pack(
@@ -475,11 +479,11 @@ def _FModel_save_soh_textures(self, exportPath):
                         0,
                         0,
                         fmt_code,
-                        texture.width,
-                        texture.height,
+                        width,
+                        height,
                         0,
-                        1.0,
-                        1.0,
+                        h_byte_scale,
+                        v_pixel_scale,
                         len(texture.data),
                     )
                     + texture.data

--- a/fast64_internal/hm64/z64/model_classes_hm64.py
+++ b/fast64_internal/hm64/z64/model_classes_hm64.py
@@ -83,7 +83,9 @@ def processTexRefNonCITextures(self: OOTModel, fMaterial: FMaterial, material: b
             )
             if isHd:
                 fImage.hd_width, fImage.hd_height = image_size
-                fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(image_size, native_size, texProp.tex_format)
+                fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(
+                    image_size, native_size, texProp.tex_format
+                )
             model.addTexture(imageKey, fImage, fMaterial)
 
         flipbook.textureNames.append(fImage.name)

--- a/fast64_internal/hm64/z64/model_classes_hm64.py
+++ b/fast64_internal/hm64/z64/model_classes_hm64.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import bpy
+from typing import Union
+
+from ...utility import PluginError
+from ...f3d.f3d_material import texFormatOf, texBitSizeF3D
+from ...f3d.flipbook import TextureFlipbook, usesFlipbook, ootFlipbookReferenceIsValid
+from ...f3d.f3d_texture_writer import getTextureNamesFromImage, writeNonCITextureData
+from ...f3d.f3d_gbi import FModel, FMaterial, FImage, FImageKey
+from ...z64.model_classes import OOTModel
+
+from ..utility import is_hm64
+from ..f3d.f3d_texture_writer_hm64 import (
+    HD_EXPORT_FORMAT,
+    computeAutoNativeSize,
+    isHdFImage,
+    resolveHdScale,
+    resolveNativeSize,
+    writeRawTextureData,
+)
+
+
+_ORIGINALS = {}
+
+
+def validateImages(self: OOTModel, material: bpy.types.Material, index: int):
+    if not is_hm64():
+        return _ORIGINALS["OOTModel.validateImages"](self, material, index)
+
+    flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}")
+    texProp = getattr(material.f3d_mat, f"tex{index}")
+    allImages = []
+    refSize = tuple(texProp.tex_reference_size)
+    for flipbookTexture in flipbookProp.textures:
+        if flipbookTexture.image is None:
+            raise PluginError(f"Flipbook for {material.name} has a texture array item that has not been set.")
+        imSize = tuple(flipbookTexture.image.size)
+        if imSize != refSize and (
+            texProp.tex_format != HD_EXPORT_FORMAT or computeAutoNativeSize(imSize, texProp.tex_format) != refSize
+        ):
+            raise PluginError(
+                f"In {material.name}: texture reference size is {refSize}, but flipbook image "
+                f"{flipbookTexture.image.filepath} size is {imSize}, which doesn't match and doesn't divide "
+                f"down to {refSize} for TMEM either."
+            )
+        if flipbookTexture.image not in allImages:
+            allImages.append(flipbookTexture.image)
+    return allImages
+
+
+def processTexRefNonCITextures(self: OOTModel, fMaterial: FMaterial, material: bpy.types.Material, index: int):
+    if not is_hm64():
+        return _ORIGINALS["OOTModel.processTexRefNonCITextures"](self, fMaterial, material, index)
+
+    model = self.getFlipbookOwner()
+    flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}")
+    texProp = getattr(material.f3d_mat, f"tex{index}")
+    if not usesFlipbook(material, flipbookProp, index, True, ootFlipbookReferenceIsValid):
+        return FModel.processTexRefNonCITextures(self, fMaterial, material, index)
+    if len(flipbookProp.textures) == 0:
+        raise PluginError(f"{str(material)} cannot have a flipbook material with no flipbook textures.")
+
+    flipbook = TextureFlipbook(flipbookProp.name, flipbookProp.exportMode, [], [])
+    allImages = self.validateImages(material, index)
+    for flipbookTexture in flipbookProp.textures:
+        imageKey = FImageKey(flipbookTexture.image, texProp.tex_format, texProp.ci_format, [flipbookTexture.image])
+        fImage = model.getTextureAndHandleShared(imageKey)
+        if fImage is None:
+            imageName, filename = getTextureNamesFromImage(flipbookTexture.image, texProp.tex_format, model)
+            if flipbookProp.exportMode == "Individual":
+                imageName = flipbookTexture.name
+
+            # Spoof this FImage's own size down to native/TMEM-legal, same as regular textures.
+            image_size = tuple(flipbookTexture.image.size)
+            if texProp.tex_format == HD_EXPORT_FORMAT:
+                native_size = resolveNativeSize(texProp, image_size)
+            else:
+                native_size = image_size
+            isHd = native_size != image_size
+            fImage = FImage(
+                imageName,
+                texFormatOf[texProp.tex_format],
+                texBitSizeF3D[texProp.tex_format],
+                native_size[0],
+                native_size[1],
+                filename,
+            )
+            if isHd:
+                fImage.hd_width, fImage.hd_height = image_size
+                fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(image_size, native_size)
+            model.addTexture(imageKey, fImage, fMaterial)
+
+        flipbook.textureNames.append(fImage.name)
+        flipbook.images.append((flipbookTexture.image, fImage))
+
+    self.addFlipbookWithRepeatCheck(flipbook)
+    return allImages, flipbook
+
+
+def writeTexRefNonCITextures(self: OOTModel, flipbook: Union[TextureFlipbook, None], texFmt: str):
+    if not is_hm64():
+        return _ORIGINALS["OOTModel.writeTexRefNonCITextures"](self, flipbook, texFmt)
+
+    if flipbook is None:
+        return FModel.writeTexRefNonCITextures(self, flipbook, texFmt)
+    for image, fImage in flipbook.images:
+        if isHdFImage(fImage):
+            writeRawTextureData(image, fImage)
+        else:
+            writeNonCITextureData(image, fImage, texFmt)
+
+
+def register():
+    _ORIGINALS["OOTModel.validateImages"] = OOTModel.validateImages
+    _ORIGINALS["OOTModel.processTexRefNonCITextures"] = OOTModel.processTexRefNonCITextures
+    _ORIGINALS["OOTModel.writeTexRefNonCITextures"] = OOTModel.writeTexRefNonCITextures
+    OOTModel.validateImages = validateImages
+    OOTModel.processTexRefNonCITextures = processTexRefNonCITextures
+    OOTModel.writeTexRefNonCITextures = writeTexRefNonCITextures
+
+
+def unregister():
+    OOTModel.validateImages = _ORIGINALS["OOTModel.validateImages"]
+    OOTModel.processTexRefNonCITextures = _ORIGINALS["OOTModel.processTexRefNonCITextures"]
+    OOTModel.writeTexRefNonCITextures = _ORIGINALS["OOTModel.writeTexRefNonCITextures"]

--- a/fast64_internal/hm64/z64/model_classes_hm64.py
+++ b/fast64_internal/hm64/z64/model_classes_hm64.py
@@ -15,6 +15,7 @@ from ..f3d.f3d_texture_writer_hm64 import (
     isHdFImage,
     resolveHdScale,
     resolveNativeSize,
+    syncMaterialReferenceSizes,
     writeRawTextureData,
 )
 
@@ -26,6 +27,7 @@ def validateImages(self: OOTModel, material: bpy.types.Material, index: int):
     if not is_hm64():
         return _ORIGINALS["OOTModel.validateImages"](self, material, index)
 
+    syncMaterialReferenceSizes(material)
     flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}")
     texProp = getattr(material.f3d_mat, f"tex{index}")
     allImages = []

--- a/fast64_internal/hm64/z64/model_classes_hm64.py
+++ b/fast64_internal/hm64/z64/model_classes_hm64.py
@@ -12,8 +12,6 @@ from ...z64.model_classes import OOTModel
 
 from ..utility import is_hm64
 from ..f3d.f3d_texture_writer_hm64 import (
-    HD_EXPORT_FORMAT,
-    computeAutoNativeSize,
     isHdFImage,
     resolveHdScale,
     resolveNativeSize,
@@ -36,9 +34,7 @@ def validateImages(self: OOTModel, material: bpy.types.Material, index: int):
         if flipbookTexture.image is None:
             raise PluginError(f"Flipbook for {material.name} has a texture array item that has not been set.")
         imSize = tuple(flipbookTexture.image.size)
-        if imSize != refSize and (
-            texProp.tex_format != HD_EXPORT_FORMAT or computeAutoNativeSize(imSize, texProp.tex_format) != refSize
-        ):
+        if imSize != refSize and resolveNativeSize(texProp, imSize) != refSize:
             raise PluginError(
                 f"In {material.name}: texture reference size is {refSize}, but flipbook image "
                 f"{flipbookTexture.image.filepath} size is {imSize}, which doesn't match and doesn't divide "
@@ -73,10 +69,7 @@ def processTexRefNonCITextures(self: OOTModel, fMaterial: FMaterial, material: b
 
             # Spoof this FImage's own size down to native/TMEM-legal, same as regular textures.
             image_size = tuple(flipbookTexture.image.size)
-            if texProp.tex_format == HD_EXPORT_FORMAT:
-                native_size = resolveNativeSize(texProp, image_size)
-            else:
-                native_size = image_size
+            native_size = resolveNativeSize(texProp, image_size)
             isHd = native_size != image_size
             fImage = FImage(
                 imageName,
@@ -88,7 +81,7 @@ def processTexRefNonCITextures(self: OOTModel, fMaterial: FMaterial, material: b
             )
             if isHd:
                 fImage.hd_width, fImage.hd_height = image_size
-                fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(image_size, native_size)
+                fImage.hd_byte_scale, fImage.hd_pixel_scale = resolveHdScale(image_size, native_size, texProp.tex_format)
             model.addTexture(imageKey, fImage, fMaterial)
 
         flipbook.textureNames.append(fImage.name)

--- a/fast64_internal/hm64/z64/model_classes_hm64.py
+++ b/fast64_internal/hm64/z64/model_classes_hm64.py
@@ -69,7 +69,7 @@ def processTexRefNonCITextures(self: OOTModel, fMaterial: FMaterial, material: b
             if flipbookProp.exportMode == "Individual":
                 imageName = flipbookTexture.name
 
-            # Spoof this FImage's own size down to native/TMEM-legal, same as regular textures.
+            # Spoof this FImage's own size down to native/TMEM-legal.
             image_size = tuple(flipbookTexture.image.size)
             native_size = resolveNativeSize(texProp, image_size)
             isHd = native_size != image_size


### PR DESCRIPTION
Adds the ability to export higher resolution images from fast64.

This is a hm64 only feature set. It works by spoofing the tmem calculator. Tmem is super finicky and ship also wants n64 tmem budget friendly values.

Works automatically and will engage the moment any material is outside the tmem budget.

Tested and confirmed working on both blender 5.2 and blender 3.3.5