### PR TITLE
Round trip correctness across the BK64 pipeline, plus level halves and texture scrolling

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2089,11 +2089,12 @@ class GfxFormatter:
 
 
 class Vtx:
-    def __init__(self, position, uv, colorOrNormal, packedNormal=0):
+    def __init__(self, position, uv, colorOrNormal, packedNormal=0, meshTag=None):
         self.position = position
         self.uv = uv
         self.colorOrNormal = colorOrNormal
         self.packedNormal = packedNormal
+        self.meshTag = meshTag  # which BK meshes claim it, never written to the binary
 
     def to_binary(self):
         signX = 1 if self.uv[0] >= 0 else -1

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -800,21 +800,23 @@ class F3DVert:
 
         return colorOrNormal, packedNormal
 
-    def toVtx(self, mesh, texDimensions, transformMatrix, isPointSampled: bool, tex_scale=(1, 1)) -> Vtx:
+    def toVtx(self, mesh, texDimensions, transformMatrix, isPointSampled: bool, tex_scale=(1, 1), meshTag=None) -> Vtx:
         # Position (8 bytes)
         position = self.convertPosition(transformMatrix)
         uv = self.convertUV(texDimensions, isPointSampled, tex_scale)
         colorOrNormal, packedNormal = self.convertNormalRGB(transformMatrix)
 
-        return Vtx(position, uv, colorOrNormal, packedNormal)
+        return Vtx(position, uv, colorOrNormal, packedNormal, meshTag)
 
 
 # groupIndex is either a vertex group (writing), or name of c variable identifying a transform group, like a limb (parsing)
 class BufferVertex:
-    def __init__(self, f3dVert: F3DVert, groupIndex: int | str, materialIndex: int):
+    def __init__(self, f3dVert: F3DVert, groupIndex: int | str, materialIndex: int, meshTag=None):
         self.f3dVert: F3DVert = f3dVert
         self.groupIndex: int | str = groupIndex
         self.materialIndex: int = materialIndex
+        # two BK meshes can hold the same point, and each needs its own Vtx to move
+        self.meshTag = meshTag
 
     def __eq__(self, other):
         if not isinstance(other, BufferVertex):
@@ -823,11 +825,12 @@ class BufferVertex:
             self.f3dVert == other.f3dVert
             and self.groupIndex == other.groupIndex
             and self.materialIndex == other.materialIndex
+            and self.meshTag == other.meshTag
         )
 
 
 class TriangleConverterInfo:
-    def __init__(self, obj, armature, f3d, transformMatrix, infoDict):
+    def __init__(self, obj, armature, f3d, transformMatrix, infoDict, meshTags=None):
         self.infoDict = infoDict
         self.vertexGroupInfo = self.infoDict.vertexGroupInfo
         self.armature = armature
@@ -835,6 +838,7 @@ class TriangleConverterInfo:
         self.mesh = obj.data
         self.f3d = f3d
         self.transformMatrix = transformMatrix
+        self.meshTags = meshTags  # one per source vertex, BK only
 
         # Caching names
         self.groupNames = {}
@@ -924,6 +928,7 @@ class TriangleConverter:
         self.texDimensions = texDimensions
         self.isPointSampled = isTexturePointSampled(material)
         self.tex_scale = material.f3d_mat.tex_scale
+        self.meshTags = triConverterInfo.meshTags
 
     def vertInBuffer(self, bufferVert, material_index):
         if self.existingVertexMaterialRegions is None:
@@ -949,7 +954,10 @@ class TriangleConverter:
         self, loop: bpy.types.MeshLoop, face: bpy.types.MeshLoopTriangle, groupIndex: int | None
     ) -> BufferVertex:
         bufferVert = BufferVertex(
-            getF3DVert(loop, face, self.convertInfo, self.triConverterInfo.mesh), groupIndex, face.material_index
+            getF3DVert(loop, face, self.convertInfo, self.triConverterInfo.mesh),
+            groupIndex,
+            face.material_index,
+            self.meshTags[loop.vertex_index] if self.meshTags else None,
         )
         return bufferVert
 
@@ -977,6 +985,7 @@ class TriangleConverter:
                         self.triConverterInfo.getTransformMatrix(bufferVert.groupIndex),
                         self.isPointSampled,
                         tex_scale=self.tex_scale,
+                        meshTag=bufferVert.meshTag,
                     )
                 )
 
@@ -1007,6 +1016,7 @@ class TriangleConverter:
                         self.triConverterInfo.getTransformMatrix(bufferVert.groupIndex),
                         self.isPointSampled,
                         tex_scale=self.tex_scale,
+                        meshTag=bufferVert.meshTag,
                     )
                 )
 

--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -3,7 +3,19 @@
 Imports and exports Banjo-Kazooie models and animations. A model can be written as an o2r resource family for the [Lighthouse](https://github.com/HarbourMasters/Lighthouse) PC port, or as a single `.bin` for the ROM hacking tools. Set the game to BK64 in the Fast64 tab to see these tools.
 
 ### Tool Locations (BK64)
-The model and animation exporters and the importers can be found in the 3D view sidebar (toggled by pressing N) under the BK64 tab. Bone properties can be found in the properties editor under the bone tab, and per material settings under the material tab.
+Everything is in the 3D view sidebar under the BK64 tab. Press N if the sidebar is hidden.
+
+- **Model Exporter** writes a model, or a level's two halves together. Format, scale, rigging and the default draw layer are set here.
+- **Animations** exports the actions on an armature, and imports one onto it.
+- **Model Importer** brings in a model, its skeleton alone, or a whole level picked by name.
+- **Mesh Tools** change the mesh you have selected: Promote Materials To 2 Cycle, Split Mesh At Bones, Select Loose Vertices, Toggle Collision Only and Add Texture Scroll.
+
+Bone settings are in the properties editor under the bone tab, and material settings under the material tab.
+
+### What A BK Model Is
+Every model is one display list drawing from one vertex list, cut into chunks. A geo layout says which chunk draws under which bone, and a bone table gives each bone a rest position and an ID that animations address. A static prop is those four things and nothing else.
+
+Everything past that is optional. A model can also carry collision triangles, collision shapes, a mesh list of vertex groups the game moves itself, animated textures, and the camera gates a level uses. Each has its own section below, and a model carrying none of them is still a model.
 
 ### What Gets Exported
 In o2r a model is not a single file, but a set of resources sharing a base path. Exporting to `models/mymodel` writes:
@@ -13,43 +25,52 @@ In o2r a model is not a single file, but a set of resources sharing a base path.
 - `mymodel_GEO`, the geo layout that binds display list ranges to bones.
 - `mymodel_tex_0`, `mymodel_tex_1` and so on, one per texture.
 
-Don't rename these or split them across folders. The port finds them by appending the suffixes to the model's own resource path. Rename a sibling and it won't be found at load time. Exporting as `.bin` puts all of it in the one file instead.
+Don't rename these or split them across folders. The port finds them by appending the suffixes to the model's own resource path. Rename a sibling and the port won't find it. Exporting as `.bin` puts all of it in the one file instead.
+
+A level is two of these families rather than one, `_OPA` and `_XLU`. "Export Level Halves", below, writes both.
 
 ### Scene Setup
 Set the game to BK64. This also sets the microcode to F3DEX/LX, which Banjo's display lists use, and fills in the world defaults. The defaults describe the RDP state the game has already set before a model's display list runs. Because a material only writes the settings that differ from them, a vanilla model's display list is nearly empty.
 
-The defaults are stored on the scene's world, and the scene needs one. A file started from Blender's General template has one. An empty file or an imported scene may not, and setting the game mode then has nowhere to write them. The export will stop with a message if the world is missing or its defaults have been changed. Pick BK64 again in the game dropdown to refill them.
+The defaults are stored on the scene's world, and the scene needs one. A file started from Blender's General template has one. An empty file or an imported scene may not, and setting the game mode then has nowhere to write them. The export stops with a message if the world is missing or its defaults have been changed. Pick BK64 again in the game dropdown to refill them.
 
 Your model should be upright with +Z up, facing -Y. The exporter converts to the N64's Y up on the way out. A static model takes its own rotation and scale with it. An armature doesn't, since a rig goes out in armature space, so apply what you turn on one. SM64 rigs in particular are often authored lying along +X, since SM64's geolayout root applies the rotation for them. Rotate those upright before exporting.
 
-Blender To BK Scale converts Blender units to BK units, and defaults to 100 as it does for SM64 and MK64. Banjo is about 138 units tall and a Jinjo about 104.
+Blender To BK Scale converts Blender units to BK units, and defaults to 100 as it does for SM64 and MK64. One Blender unit becomes that many BK units, so at 100 Banjo stands 1.38 units tall in Blender and a Jinjo 1.04. Those are heights, not scale values. Either importer fills the scale in, and any value round trips as long as import and export agree.
 
 Animation Scale multiplies the translation channel of any animation played on the model. It only matters for animated models, where either importer fills it in for you when replacing a vanilla model.
 
 Resource Path is where the model is stored inside the archive. Use anything you like for a new model, or a vanilla model's own path to replace it.
 
 ### Materials
-Materials must be **2 cycle**. Every model the game draws is set up in 2 cycle mode, and the render modes it provides put the real blending in the second cycle. A 1 cycle material renders black. Materials created while in BK64 mode are 2 cycle already. The export fails and lists any that aren't. "Promote Materials To 2 Cycle" converts every material on the selected mesh at once. The second cycle it adds only passes the first cycle's result through, leaving nothing to configure.
+Materials must be **2 cycle**. Every model the game draws is set up in 2 cycle mode, and the render modes it provides put the real blending in the second cycle. A 1 cycle material never reaches that second cycle. It draws with the pass-through blender the table puts in the first, and anything meant to be see-through comes out solid. Materials created while in BK64 mode are 2 cycle already, so this only comes up on a mesh brought in from elsewhere, where 1 cycle presets are common. The export fails and lists any that aren't. "Promote Materials To 2 Cycle" converts every material on the selected mesh at once. The second cycle it adds only passes the first cycle's result through, leaving what you set up in the first alone and nothing new to configure.
 
 Meshes must use F3D materials, as they do everywhere else in Fast64. If you have a model with Principled BSDF materials, use the Principled BSDF to F3D conversion operator to convert them.
 
-Shading comes from vertex color. The game loads no lights for a model. A vanilla model carries its shading baked into its vertices instead, and Banjo himself uses 61 different shades that way.
+Shading comes from vertex color. The game loads no lights for a model. A vanilla model carries its shading baked into its vertices instead.
 
 The vertex color's alpha channel only reaches the output if the alpha combiner takes SHADE. "BK Vertex Colored Texture" holds alpha at 1, so painting that channel does nothing there. Use "BK Vertex Colored Texture Transparent", which takes shade alpha in the first cycle and scales it by the primitive color's alpha in the second, giving one fade control over the whole material. "BK Vertex Colored Texture Cutout" takes the texture's alpha instead, for foliage and railings that are vertex shaded.
 
 No preset sets a render mode, and none should. A chunk jumps into the render mode table the game builds instead, picked by its Draw Layer. Ticking Set Render Mode writes a mode into the display list after that jump, which overrides it and takes the actor's depth behavior away from the game.
 
-The viewport previews a material the way its render mode preset describes, so a cutout clips and a transparent one blends while you work. That preset is preview only. What the game actually renders with comes from Draw Layer, below, and the two are set independently: a translucent preset on the opaque layer previews blended and ships solid.
+The viewport previews a material the way its render mode preset describes, so a cutout clips and a transparent one blends while you work. That preset is preview only. What the game actually renders with comes from Draw Layer, below. The transparent presets set that for you, so the two start out agreeing. Nothing holds them together afterwards: move a material to the opaque layer and it still previews blended while it ships solid.
 
 Force Unlit Shade, on by default, does that baking. It calculates what the RSP would have shaded each vertex, ambient plus every light facing it, from the material's light colors and directions and the vertex normal. The result goes to the vertex color. An unlit material already has a color there and passes it through untouched. A mesh painted by hand or baked in Blender exports as it looks.
 
-Reflective materials need the Reflective (Env Map) option. It sets up the reflection matrix that G_TEXTURE_GEN environment mapping needs. Reflection is the one place the lighting flag earns its keep despite no lights being loaded, since that flag transforms the normal the reflection samples. A reflective material therefore keeps both the flag and its vertex normals through the export, where every other material has its shading baked down into vertex color.
+Reflective materials need the Reflective (Env Map) option. It sets up the reflection matrix that G_TEXTURE_GEN environment mapping needs. The lighting flag has to stay on for it, with no lights loaded, because that flag transforms the normal the reflection samples. A reflective material therefore keeps both the flag and its vertex normals through the export, where every other material has its shading baked down into vertex color.
 
 Trilinear Mipmap is the other geo type flag and is off by default. With it on, any 32x32 RGBA16 material whose combiner blends two texels gets a mip pyramid written. A texture imported from the game writes back the levels it came in with, which Rare drew by hand. Edit the base and the levels are filtered from it instead.
 
-Draw Layer is Opaque for solid geometry and Translucent for blended. A model does not set a render mode directly. The game builds a table of render modes from whether the actor wants depth writing, depth compare or neither, and the model picks an entry from that table. Depth behavior stays with the game. If a model overrides it, other things in the world will lose their depth test against that model.
+Both boxes only apply to a model you built yourself. An imported one keeps the flags it arrived with, and the panel greys the boxes out and shows the value as Imported Geo Type. Set that to 0 to take the boxes back. A level's two halves usually disagree, which is why the flags are kept per object rather than per scene.
 
-The Draw Layer on the export panel applies to the whole model, though a material can override it in the material tab. Faces using a different layer become their own chunk. A solid body with a see-through visor exports as one model with two chunks on one bone.
+Draw Layer is Opaque for solid geometry and Translucent for blended. A model doesn't set a render mode directly. The game builds a table of render modes from whether the actor wants depth writing, depth compare or neither, and the model picks an entry from that table. Depth behavior stays with the game. If a model overrides it, other things in the world lose their depth test against that model.
+
+Default Draw Layer on the export panel is what a material takes when its own is From Scene, so it applies to everything you haven't set explicitly. Faces using a different layer become their own chunk. A solid body with a see-through visor exports as one model with two chunks on one bone.
+
+#### Draw Order
+Materials export in the order of the object's material slots, and the game draws them in that order. Where two surfaces overlap and neither writes depth, the one drawn later is the one you see. Moving a material down the list brings its faces out in front of the ones above it.
+
+A model built from several objects sorts by object name first, since the export walks the root's children in name order. Material slots then order the faces within each object.
 
 ### Textures
 Fast64 converts textures to native N64 formats and the exporter writes them through untouched. RGBA16, RGBA32, CI4, CI8, I4, I8, IA4, IA8 and IA16 are all supported. BK stores a texture's width and height as a single byte each. Neither can exceed 255. The export fails with a message instead of truncating.
@@ -58,14 +79,14 @@ A paletted texture is split in two. The image goes out as its own `_tex_<i>` sib
 
 Large Texture Mode is not supported. It splits a mesh into pieces that each load part of an image, but BK binds a texture whole, by index for a resource and by offset for a `.bin`. Scale the image down to fit TMEM instead.
 
-Tile settings default to wrap. A model imported from a format with no equivalent loses whatever it was authored with. Any face whose UVs reach past the tile edge will then sample from the far side of the texture instead of stopping at it. That shows up as streaks and smears across otherwise flat surfaces. Set Clamp on S and T for those materials.
+Tile settings default to wrap. A model imported from a format with no equivalent loses whatever it was authored with. Any face whose UVs reach past the tile edge then samples from the far side of the texture instead of stopping at it. That shows up as streaks and smears across otherwise flat surfaces. Set Clamp on S and T for those materials.
 
 ### Animated Textures
 A material's texture can cycle through a set of frames, which is how the Beauty Machine's screen flickers and how lightning flashes. Set Animated Texture on the material, then list every frame under it starting with the one the material already samples. Frames Per Second is what it sounds like, and vanilla runs between 4 and 15.
 
 Every frame shares one size and one format, and that format is RGBA16, RGBA32 or IA8. A CI4 or CI8 frame would have to animate its palette alongside the image, and the exporter refuses rather than writing something the game reads past the end of.
 
-The game doesn't swap textures. It stacks the frames end to end in the model's texture data and slides a pointer along them, and that is why every frame has to be the same size. Four slots exist and slot 0 is the only one vanilla ever uses. Use another only if a model animates more than one texture at once.
+The game doesn't swap textures. It stacks the frames end to end in the model's texture data and slides a pointer along them, and that's why every frame has to be the same size. Four slots exist and slot 0 is the only one vanilla ever uses. Use another only if a model animates more than one texture at once.
 
 ### Exporting A Model
 For a static model such as a prop or a set piece, select the mesh and click "Export BK Model". Nothing else is needed.
@@ -77,15 +98,15 @@ For a rigged model select the armature instead, and any mesh parented to it is i
 
 Banjo's skinning is rigid either way: there are no vertex weights, and each vertex follows exactly one bone. A seam is closed by a face's corners following different bones, not by blending weights. The Rigging setting picks how the model records which vertex follows which bone, and the game supports two methods.
 
-**Split At Bones** gives every bone its own display list and draws each under its own matrix. A face can stay welded across a bone and its parent, the one seam the game's skinning blends. Anywhere else, the mesh has to be cut. 141 vanilla models are built this way.
+**Split At Bones** gives every bone its own display list and draws each under its own matrix. A face can stay welded across a bone and its parent, the one seam the game's skinning blends. Anywhere else, the mesh has to be cut.
 
 The export refuses an illegal weld instead of cutting it for you. Use "Split Mesh At Bones" to make the cuts in the scene, where you can check them.
 
-**Bind Vertices** keeps the mesh whole and writes a table beside it naming the bone each vertex follows. Before drawing, the game walks that table, takes each entry's rest position, puts it through that bone's matrix, and writes the result into the vertices the entry lists. One triangle can then reach across a joint with its corners on different bones, closing the seam without modeling around it. 116 vanilla models are built this way, including Gruntilda, Boggy and Gobi.
+**Bind Vertices** keeps the mesh whole and writes a table beside it naming the bone each vertex follows. Before drawing, the game walks that table, takes each entry's rest position, puts it through that bone's matrix, and writes the result into the vertices the entry lists. One triangle can then reach across a joint with its corners on different bones, closing the seam without modeling around it. Gruntilda, Boggy and Gobi are built this way.
 
 A vertex no bone weights is left out of that table and holds its rest pose while the model moves. The export warns and names the coordinate, and "Select Loose Vertices" picks them out in the scene.
 
-No vanilla model mixes the two, and neither does the exporter. Pick one per model. Everything else is the same: the bone table goes out unchanged and animations play on either.
+The exporter doesn't mix the two, and no vanilla model does either. Pick one per model. Everything else is the same: the bone table goes out unchanged and animations play on either.
 
 Setting a Geo Type on a bone only takes effect with Split At Bones, apart from Reference Point. The other nodes pick between the geometry of different bones, and a bound model draws under none of them. A reference point draws nothing at all, and only reports where a joint landed. A bound model imported from the game does keep the selectors, sorts and reference points it arrived with, and round trips with them intact. With either method, only the first 128 bones in the table can own a display list, though bones past that still animate.
 
@@ -93,51 +114,23 @@ A model standing in for one of Banjo's transformations has to carry a Reference 
 
 Bound entries are keyed by rest position. Two vertices at exactly the same position go to the same bone regardless of their vertex groups. Move one of them if a joint needs them apart.
 
-### Exporting An Animation
-Pose the armature into an action, select it, and click "Export BK Animation". The action's own frame range is exported, one resource per action, to the Animation Path you set.
-
-An animation is a set of curves addressed by bone ID and isn't tied to the model it was authored on. Any model whose table carries the same IDs can play it, which is how a replacement character plays the animations the game already has for it.
-
-Animation Scale has to match the model the animation plays on. Because it multiplies the translation channels, the same values move a Jinjo and a Grunty different distances. The skeleton importer fills it in from whichever model you imported. If it's wrong, the rotations will still be correct but the model will slide the wrong distance.
-
-Every channel is sampled once per frame and at half frames, then reduced to the fewest keys the game's reader can reproduce all of those samples from. Keys are flagged smooth. The game splines between them and a curve stays a curve. Rotation is stored in degrees and translation in animation units, both to a 64th. The exporter stops instead of writing a value larger than an s16 holds.
-
-Translation resolution is limited by that 64th. One step is Animation Scale divided by 64, which is 1.4 BK units on the Grublin, and nothing can land closer than that.
-
-Hold Unanimated Bones, on by default, writes one resting key for every bone the action never moves. The game keeps one set of bone transforms per actor and only overwrites what the current animation mentions. A bone left out of a replacement animation keeps whatever the animation before it left there. Turning it off produces a smaller file that matches how vanilla animations are built, with that risk.
-
-An animation loops by returning to progress zero. For anything that repeats, make the last frame's pose match the first.
-
-"Export All Actions" writes every action in the file that has a curve on a bone of the selected armature, each named after the action and placed in the same folder as the Animation Path. Name the actions after the assets they replace to export a whole character's animation set at once. An action belonging to another rig is skipped, not exported as a model standing still.
-
-### Collision
-Scenery carries collision, characters don't: no vanilla character model has any, while over half the models that do are props, platforms and doors.
-
-Collision is set per material, under BK64 Collision in the material tab. Leave it at No Collision and those faces stay out of the list, which is how an ordinary model exports with none. Set it to Ground and Banjo can stand on those faces. Sound Type picks the footstep. Map Default and the numbered map sounds resolve through the map the model loads into, so a level replacing TTC gets sand. The named sounds are the same everywhere, and the Surface Flags cover slopes, hazards and the rest.
-
-The triangles reference the model's own vertices. Collision costs a triangle list and nothing more.
-
-Collision doesn't have to follow the mesh. Select a mesh and press Toggle Collision Only. It stops drawing but still collides: an invisible floor, a barrier across a gap, or a cheap box standing in for something detailed. Give every face a material with a Collision Type set, since a face with none is an error rather than a guess. The mesh goes out as extra vertices on the end of the model's own list, the way vanilla does it, and the model's radius grows to reach them.
-
-Vanilla leans on this. Over 90 models collide against geometry they never draw, the beehive and Mumbo's hut among them, and those come in as a `<name>_collision_only` mesh so a re-export keeps them.
-
 ### Bone IDs
-Animations address bones by ID, not by name or position. Each bone has a BK Bone ID in the bone tab. Leaving it at 0 makes the exporter assign IDs sequentially, fine for a model that ships its own animations.
+Animations address bones by ID, not by name or position, so the IDs your bone table carries decide which animations your model can play. Which way you set them depends on where the animations come from.
 
-An animation channel aimed at an ID that isn't in the table moves nothing at all. There's no crash, the bone just holds its rest pose, and a mismatched skeleton is easy to miss.
+If the model brings its own, leave every BK Bone ID at 0 in the bone tab. The exporter numbers the table for you, and the animations you export from that armature address the numbers it chose.
 
-IDs run up to 0x6C. The game looks them up in a fixed length table without checking, and the export refuses anything higher.
+If the model replaces a vanilla one and you want the game's existing animations to play on it, the IDs have to be the ones those animations already address. Import the original skeleton and build on it rather than numbering by hand. Getting this wrong is quiet. A channel aimed at an ID the table doesn't have moves nothing, with no crash, so the bone just holds its rest pose. A skeleton a few IDs out looks like a bad animation rather than a numbering mistake.
 
-A model with no bones at all in an animated slot crashes the game. Ship a bone table for anything animated.
+Two limits apply either way. An ID can't go past 0x6C, because the game indexes a fixed length table without checking, and the export refuses anything higher. And a model in an animated slot has to have a bone table at all, since the game crashes on one with no bones.
 
-BK Bone Order is the bone's position in the exported table. The skeleton importer sets it and the exporter honors it. A model imported from the game and exported back out keeps its original table order. Left at -1, bones are ordered by name instead.
+BK Bone Order is a different setting: where a bone sits in the exported table, not what addresses it. The skeleton importer fills it in so a vanilla model goes back out in its original order. On a model of your own, leave it at -1 and bones are ordered by name.
 
 ### Geo Nodes
 As well as carrying geometry, a bone can act as a node in the geo layout, set by Geo Type in the bone tab.
 
-**Selector** draws one of its child bones at a time. The game keeps a visibility value per appendage id and the selector reads it: 1 draws the first child, 2 the second, 0 draws nothing, and a negative value is a bit mask that draws several. Set Appendage ID to the id the game will address, from 1 to 41, and parent one bone per option to the selector. Everything under an option bone goes with it.
+**Selector** draws one of its child bones at a time. The game keeps a visibility value per appendage id and the selector reads it: 1 draws the first child, 2 the second, 0 draws nothing, and a negative value is a bit mask that draws several. Set Appendage ID to the id the game addresses, from 1 to 41, and parent one bone per option to the selector. Everything under an option bone goes with it.
 
-The value is not set automatically. An actor has to call `modelRender_setAppendageVisibility`. Until one does, a selector on a replacement model reads whatever was left in the slot unless the actor is changed to drive it. That requires a port change and can't be done by the exporter.
+The value isn't set automatically. An actor has to call `modelRender_setAppendageVisibility`. Until one does, a selector on a replacement model reads whatever was left in the slot unless the actor is changed to drive it. That requires a port change and can't be done by the exporter.
 
 **Level Of Detail** draws what's under it only while the camera is between Near Distance and Far Distance of the joint, both in BK units. Far Distance has to be set or it never draws.
 
@@ -147,43 +140,94 @@ The value is not set automatically. An actor has to call `modelRender_setAppenda
 
 **Reference Point** reports where a joint is in a numbered slot the actor reads back, letting effects hang off a model. Set Point Slot to the number the actor expects. The point uses the bone's own matrix and lands wherever the bone's head is once the animation has moved it.
 
+### Exporting An Animation
+Pose the armature into an action, select it, and click "Export BK Animation". The action's own frame range is exported, one resource per action, to the Animation Path you set.
+
+An animation is a set of curves addressed by bone ID and isn't tied to the model it was authored on. Any model whose table carries the same IDs can play it, which is how a replacement character plays the animations the game already has for it.
+
+Animation Scale has to match the model the animation plays on. Because it multiplies the translation channels, the same values move a Jinjo and a Grunty different distances. The skeleton importer fills it in from whichever model you imported. If it's wrong, the rotations are still correct but the model slides the wrong distance.
+
+Every channel is sampled once per frame and at half frames, then reduced to the fewest keys the game's reader can reproduce all of those samples from. Keys are flagged smooth. The game splines between them and a curve stays a curve. Rotation is stored in degrees and translation in animation units, both to a 64th. The exporter stops instead of writing a value larger than an s16 holds.
+
+Translation resolution is limited by that 64th. One step is Animation Scale divided by 64, and nothing can land closer than that.
+
+Hold Unanimated Bones, on by default, writes one resting key for every bone the action never moves. The game keeps one set of bone transforms per actor and only overwrites what the current animation mentions. A bone left out of a replacement animation keeps whatever the animation before it left there. Turning it off produces a smaller file that matches how vanilla animations are built, with that risk.
+
+An animation loops by returning to progress zero. For anything that repeats, make the last frame's pose match the first.
+
+"Export All Actions" writes every action in the file that has a curve on a bone of the selected armature, each named after the action and placed in the same folder as the Animation Path. Name the actions after the assets they replace to export a whole character's animation set at once. An action belonging to another rig is skipped, not exported as a model standing still.
+
+### Collision
+Scenery carries collision, characters don't.
+
+Collision is set per material, under BK64 Collision in the material tab. Leave it at No Collision and those faces stay out of the list, which is how an ordinary model exports with none. Set it to Ground and Banjo can stand on those faces. Sound Type picks the footstep. Map Default and the numbered map sounds resolve through the map the model loads into, so a level replacing TTC gets sand. The named sounds are the same everywhere, and the Surface Flags cover slopes, hazards and the rest.
+
+The triangles reference the model's own vertices. Collision costs a triangle list and nothing more.
+
+Collision doesn't have to follow the mesh. Select a mesh and press Toggle Collision Only. It stops drawing but still collides: an invisible floor, a barrier across a gap, or a cheap box standing in for something detailed. Give every face a material with a Collision Type set, since a face with none is an error rather than a guess. The mesh goes out as extra vertices on the end of the model's own list, the way vanilla does it, and the model's radius grows to reach them.
+
+Vanilla leans on this, the beehive and Mumbo's hut among them. Those come in as a `<name>_collision_only` mesh, so a re-export keeps them.
+
 ### Collision Shapes
-A model can carry a set of volumes the game collides against, separately from the collision triangles: boxes, cylinders and spheres, each optionally riding a bone so it follows the animation. The Grublin has five spheres, on its head, both hands, its torso and its base.
+Collision shapes are volumes the game tests against, separate from the collision triangles: boxes, cylinders and spheres, each able to ride a bone so it follows the animation. They decide whether one thing has touched another. A model with none is still collidable, just more roughly, since the game falls back to comparing a pair of plain spheres. The Grublin has five, on its head, both hands, its torso and its base.
 
-The game uses them to decide whether one thing has touched another. Without them it compares a pair of plain spheres instead. A model with no shapes is still collidable, just more roughly. The first sphere is also used as the volume swept against the world to decide whether a move is allowed. A map model uses the same structure for named regions that the game queries by code. That is how Mad Monster Mansion knows to change the music when you step inside.
+Make one by putting an object under the model with a Shape custom property. Its own transform is the shape, so move, rotate and scale it to fit, and parent it to a bone to make it follow that bone. The first sphere does double duty as the volume swept against the world to decide whether a move is allowed, so put that one on the body. The cull radius tested before any shape is the model's own radius, the way every vanilla model has it, so there's nothing to set.
 
-The import brings them in as wire objects in their own `<name>_collision_shapes` collection, marked Ignore Render so the model export leaves them alone, parented to the bone they name. Their undecoded fields ride along as custom properties.
+Set Hit Code to 255 unless something in the game needs to tell this shape from the others. The code is a label rather than a setting. 0 means every search skips the shape and 255 marks a plain volume, and small numbers are used where something is looking for one in particular. The jigsaw puzzle numbers its twenty pieces 1 to 20 so the game can ask which one you're standing on. Several shapes can share a code, so a search can ask whether a point is inside any of them.
 
-Each shape carries a code, a label and not a setting. 0 means every search skips it. 255 marks a plain volume nothing needs to tell apart from the others, and small numbers are used where something does. The jigsaw puzzle numbers its twenty pieces 1 to 20 so the game can ask which one you are standing on. What a number means is decided by whatever queries it, and several shapes can share one so the game can ask whether a point is in any of them.
-
-Shapes are exported too. Any object under the model with a Shape custom property is written as one, taken from its own transform. Move, rotate and scale it to set the shape. Parent it to a bone and it will follow that bone. Set Hit Code to 255 unless something in the game needs to tell this shape from the others. The cull radius the game tests before checking any shape is the model's own radius, the way every vanilla model sets it.
+An import brings shapes in as wire objects in a `<name>_collision_shapes` collection, marked Ignore Render so the model export leaves them alone, parented to the bone they name. Their undecoded fields ride along as custom properties. A map model uses the same structure for named regions the game queries by code. That is how Mad Monster Mansion knows to change the music when you step inside.
 
 ### Mesh Lists
-Some models hand the game a set of vertex groups it moves on its own: the sky, the map model, Bottles' bonus bookshelf and the jigsaw puzzle. 43 vanilla models carry one.
+A mesh list hands the game a set of vertex groups it animates by itself, with no actor driving them. Water that rises and falls, a light that flickers, a texture that scrolls. The sky, the map model, Bottles' bonus bookshelf and the jigsaw puzzle all carry one.
 
-A mesh comes in as a vertex group named `bk64_mesh_<uid>`, and any group named that way goes back out as one. The uid is the name the game looks a mesh up by, not a position in the list. Keep the numbers the original used and give a mesh of your own a number nothing else has taken.
+You don't pick the effect, the game does, by number. A mesh is a vertex group named `bk64_mesh_<uid>`, any group named that way goes back out as one, and the uid is what the game looks it up by. Which uid gets which effect is decided in the game's own code, so a mesh of yours animates only if you give it a uid the map already drives. Anything else needs a port change, not an export setting.
 
-Which vertices belong to a mesh is worked out from their positions on the way out, the same as Bind Vertices. A model that stacks geometry at one coordinate can't be split back apart exactly. A re-export puts a few more vertices in a mesh than vanilla did. The import says so when it reads one. The jigsaw is the worst of them, its twenty pieces being the same shape in the same place.
+The uid carries the effect and its setting in one number. Which hundred it falls in picks the effect, and the rest is that effect's only parameter. Meshes 101 to 199 scroll their texture at a speed of uid minus 100. 200 to 299 flicker. 300 to 399 rise and fall, which is what water in a translucent half uses. The bands run to 1099, so anything above 399 is driven too.
+
+Scrolling is the one you can set up without touching the port. Select the faces in edit mode, set Scroll Speed, and press "Add Texture Scroll". Speed 20 is what Gobi's Valley uses for its sand. Only the vertical texture coordinate moves, so the texture slides one way rather than drifting. Banjo's Backpack calls this Scroll Texture, and its Slow, Normal and Fast are speeds 6, 20 and 60.
+
+Some uids are addresses for gameplay code rather than effects, and those you have to leave where they are. Gobi's Valley works out which sphinx tile Banjo is standing on by asking which mesh from 400 to 415 his position falls inside. Furnace Fun does the same from 401 to 495, and Mad Monster Mansion's shed and Treasure Trove Cove's castle ask over every mesh they have. Moving or renumbering one of those moves the region with it.
+
+Two things to expect from a round trip. Membership rides on the vertices themselves, so a mesh exports with the vertices its group holds even where two meshes meet at one coordinate. And vanilla lists some vertices no triangle draws, which have no geometry to come in on. Re-exporting one of those models gives a slightly shorter list than the original.
+
+### Importing A Model
+"Import BK Model" reads a model resource or a `.bin`, and everything that came with it: mesh, UVs, vertex colors, textures, materials, the armature with its bone ids, and Animation Scale. The format is detected from the file, leaving nothing to set. Point Model File at a resource and keep its `_GEO`, `_VTX` and `_tex_<i>` siblings in the same folder; a `.bin` carries all of that already.
+
+The mesh comes in as one object with a vertex group per bone, each vertex in the group of the bone that moves it. At a joint that's the parent bone, which is why posing the armature in Blender deforms the mesh the way the game does. Materials carry the texture, the combiner, the tile wrap modes and the collision the faces were drawn with.
+
+The geo layout comes in with the model and goes back out on export: selectors, sorts, skinned seams and mipmapped materials all survive the round trip, along with your mesh edits. Geometry you add is drawn after the original layout, under whichever bone you weight it to.
+
+Both rigging methods come in weighted. A Split At Bones model takes its weights from the layout, a bound one from its binding table. Gruntilda, Boggy and Gobi arrive posable, not as a bare mesh sitting beside an armature. The import sets Rigging to whichever of the two it found.
+
+A Split At Bones model also remembers which chunk each face was drawn in, and that decides the bone the face draws under ahead of its weights. It's what keeps a vanilla model on its original bones through a round trip, but it means re-weighting an imported face doesn't move it. Delete the mesh's `hm64_bk64_source` attribute when you mean to re-rig, and the weights decide instead.
+
+The collision fields describe every flag word vanilla ships. A word only a romhack sets comes in as Raw Flags and goes back out exactly as it arrived; clear that field to author the surface with the fields instead.
+
+Imported materials come in unlit, apart from the reflective ones, because a BK model already carries its shading in its vertex colors and has nothing to calculate from the normals. Leave them unlit and a re-export keeps those colors exactly. Turn lighting on and the export bakes new shading from the material's lights instead, the right choice for a model you built yourself.
+
+"Import BK Skeleton" does the same for the bones alone, when the mesh isn't wanted, and reads either format too.
 
 ### Importing An Animation
 "Import BK Animation" reads an animation onto the selected armature as a new action, one keyframe per frame. Bones are matched by ID. Import the skeleton of the model the animation belongs to first. An animation naming an ID the rig doesn't have is refused rather than partly applied.
 
 An imported animation is not a byte for byte copy of the original when exported again. It is exact on every whole frame, to within the translation step above. Between two frames it can differ by a couple of BK units. A key can only sit on a whole frame, and the original's curve leaves the line through its own per frame values by up to two degrees. Use this to read an animation to see how it moves, or to adjust it.
 
-### Importing A Model
-"Import BK Model" reads a model resource or a `.bin`, and everything that came with it: mesh, UVs, vertex colors, textures, materials, the armature with its bone ids, and Animation Scale. The format is detected from the file, leaving nothing to set. Point Model File at a resource and keep its `_GEO`, `_VTX` and `_tex_<i>` siblings in the same folder; a `.bin` carries all of that already.
+### Levels
+A level's geometry is two models rather than one. The game loads an opaque half and a translucent half as separate resources, named for the level and which half they are: Treasure Trove Cove is `ASSET_146B_TTC_TREASURE_TROVE_COVE_OPA` and `ASSET_146C_TTC_TREASURE_TROVE_COVE_XLU`. Most maps have both halves, and some only the OPA.
 
-The mesh comes in as one object with a vertex group per bone, each vertex in the group of the bone that moves it. At a joint that is the parent bone, which is why posing the armature in Blender deforms the mesh the way the game will. Materials carry the texture, the combiner, the tile wrap modes and the collision the faces were drawn with.
+The halves are not opaque and translucent geometry sorted by material. What the split decides is depth. OPA draws with depth writing on, XLU with depth compare only. Geometry in the second half is tested against what is already there, but never hides anything behind it. Each half then has its own opaque and translucent render modes, which a material's Draw Layer picks between. That is why an opaque model still carries translucent faces: they blend, and they still write depth. Which half a piece of geometry goes in is your call, the same choice Banjo's Backpack offers with its A and B model slots.
 
-The geo layout comes in with the model and goes back out on export: selectors, sorts, skinned seams and mipmapped materials all survive the round trip, along with your mesh edits. Geometry you add is drawn after the original layout, under whichever bone you weight it to.
+"Import BK Level" finds them by name, so point Level Folder at the folder you unpacked `bk.o2r` into and pick the level rather than hunting for asset ids. Halves brings in one or both, each as its own object, tagged with the half it came from.
 
-Both rigging methods come in weighted. A Split At Bones model takes its weights from the layout, a bound one from its binding table. Gruntilda, Boggy and Gobi arrive posable, not as a bare mesh sitting beside an armature. The import reports which of the two it found.
+A level's camera gates come in with it, as wire objects in a `<name>_camera_areas` collection. A CAMERA command in the geo layout names one by index and draws what hangs off it only while the camera is inside that box, or outside it. Move a box to move the gate. Delete one and everything it gated stops drawing.
 
-The collision fields describe every flag word vanilla ships. A word only a romhack sets comes in as Raw Flags and goes back out exactly as it arrived; clear that field to author the surface with the fields instead.
+Level Half on the export panel is that tag. Set it on every object in your level, then "Export Level Halves" writes both models in one go. A level brought in with Halves set to Both is already tagged and needs nothing set.
 
-Imported materials come in unlit, apart from the reflective ones, because a BK model already carries its shading in its vertex colors and has nothing to calculate from the normals. Leave them unlit and a re-export keeps those colors exactly. Turn lighting on and the export bakes new shading from the material's lights instead, the right choice for a model you built yourself.
+The naming is handled for you. A level of your own gets `_OPA` and `_XLU` on the end of its Resource Path. A vanilla level gets the two names the port loads it by, and those differ by more than the suffix: Gobi's Valley is `ASSET_1474_GV_GOBIS_VALLEY_OPA` and `ASSET_1475_GV_GOBIS_VALLEY_XLU`. Point Resource Path at either one and both come out right.
 
-"Import BK Skeleton" does the same for the bones alone, when the mesh is not wanted, and reads either format too.
+Both halves go out every time, even an empty one, so replacing a level can't leave its old half standing. A half you gave no geometry is written as a model that draws nothing. An opaque only level still gets a translucent model, named from its own asset, for a hack meaning to add one. The map only draws it once its scene definition names an xlu asset.
+
+Default Draw Layer is not that control. Setting it to Translucent will not move faces between halves, it just puts every material you haven't set explicitly onto that layer, opaque geometry included.
 
 ### Replacing A Vanilla Model
 To stand in for a vanilla model, your bone table needs to carry the bone IDs that model's animations address. Starting from the original skeleton is much safer than building one from scratch.
@@ -194,9 +238,9 @@ To stand in for a vanilla model, your bone table needs to carry the bone IDs tha
 3. Set Resource Path to the vanilla model's own path, for example `assets/model/ASSET_3C0_JINJO_BLUE`.
 4. Export, pack, and drop the archive in the `mods` folder.
 
-43 of the 659 vanilla models carry a mesh list, and an actor whose model has one builds from it the moment it spawns without checking. A stand-in that carries none crashes instead of just looking wrong. Keep the mesh groups the import creates and put your own geometry in them. Tee-hee, Mutie Snippet and the Twinklies are among these.
+An actor whose model has a mesh list builds from it the moment it spawns, without checking. A stand-in that carries none crashes instead of just looking wrong. Keep the mesh groups the import creates and put your own geometry in them. Tee-hee, Mutie Snippet and the Twinklies are among these.
 
-Bones come in at their original rest positions, and a third of them sit exactly on their parent. That is 1736 of the game's 5150 bones, across 218 of the 257 rigged models. These are still real table entries. Deleting one doesn't merge it into its neighbor, it removes a link from the chain and leaves whichever animation channel addressed that ID moving nothing.
+Bones come in at their original rest positions, and many sit exactly on their parent. These are still real table entries. Deleting one doesn't merge it into its neighbor, it removes a link from the chain and leaves whichever animation channel addressed that ID moving nothing.
 
 ### Getting It Into The Game
 Format sets what is written, for animations as well as models. O2R writes the resource family described above, for the HarbourMasters ports. BK Model Binary writes a single `.bin` in the game's own format, which the ROM hacking tools read.
@@ -214,11 +258,7 @@ torch pack <export folder> <name>.o2r o2r
 Drop the resulting `.o2r` in Lighthouse's `mods` folder.
 
 ### What Doesn't Come Back
-Two parts of the format are read past and not kept. A model carrying one exports without it.
-
-**Cull spheres**, geo command 0x0E, skip whatever hangs off them while the sphere is off screen. The import follows the branch and keeps the geometry under it, but flattens the sphere away. Only ASSET_88E_CLANKER_CHAIN has any, and losing them draws the same picture for slightly more work. Nothing is wrong with the model that comes back. Use Draw Distance for a model of your own that needs culling.
-
-**Camera areas** are in no model at all, and aren't written.
+Cull spheres, geo command 0x0E, are the one part of the format read past and not kept. They skip whatever hangs off them while the sphere is off screen. The import keeps the geometry under one but flattens the sphere away, and a model carrying one exports without it. Only ASSET_88E_CLANKER_CHAIN has any, and losing them draws the same picture for slightly more work. Use Draw Distance for a model of your own that needs culling.
 
 ### Common Issues
 - The model renders black: a material still has lighting enabled and Force Unlit Shade is off.
@@ -226,6 +266,8 @@ Two parts of the format are read past and not kept. A model carrying one exports
 - It animates, but some limbs hold their rest pose: those bones' IDs aren't the ones the animation addresses. Import the original model's skeleton and match its IDs.
 - An exported animation moves the model too far or not far enough: Animation Scale doesn't match the model it's playing on.
 - Streaks or smears across flat surfaces: the tiles are set to wrap and some UVs reach past the tile edge. Set Clamp on S and T.
+- The export still calls the mesh welded after you ran Split Mesh At Bones: a modifier is making the welded geometry. The split cuts the mesh itself, the export reads it with its modifiers applied. Apply them first.
+- A re-weighted limb still follows the bone it had before: its faces kept the chunk they were imported in, which outranks their weights. Delete the mesh's `hm64_bk64_source` attribute.
 - Limbs tear at the joints: the seam faces are cut, or welded across bones that aren't parent and child. Weld the seam to the joint's own bone pair, overlap the limbs, or switch to Bind Vertices.
 - A single vertex stretches away from the model as it animates: it carries no weight to a bone's vertex group, so Bind Vertices leaves it behind at rest. Run Select Loose Vertices and weight what it finds.
 - Select Loose Vertices finds nothing but the export still warned: a modifier is making that geometry. The export reads the mesh with its modifiers applied, and Boolean, Remesh, Skin and Geometry Nodes drop vertex groups.

--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -75,6 +75,15 @@ A model built from several objects sorts by object name first, since the export 
 ### Textures
 Fast64 converts textures to native N64 formats and the exporter writes them through untouched. RGBA16, RGBA32, CI4, CI8, I4, I8, IA4, IA8 and IA16 are all supported. BK stores a texture's width and height as a single byte each. Neither can exceed 255. The export fails with a message instead of truncating.
 
+A texture also has to fit TMEM, which holds 4KB, or 2KB for a CI format since the palette takes the rest. The biggest that fit:
+
+- RGBA32: 32x32, 16x64, 8x128
+- RGBA16, IA16 and CI8: 32x64, 64x32, 16x128, 8x256
+- I8, IA8 and CI4: 64x64, 32x128, 128x32, 16x256
+- I4 and IA4: 64x128, 128x64, 32x256, 256x32
+
+Halving one side lets the other double, and the material tab shows what a texture uses against that budget. Going over isn't an error. Fast64 keeps the image whole and writes it as an HD texture: a smaller tile stands in for it in the display list, with the scales beside it saying how much bigger the real image is. Only an o2r export can carry those scales. A `.bin` stores its images as bare bytes with nowhere to record them, and refuses.
+
 A paletted texture is split in two. The image goes out as its own `_tex_<i>` sibling while its palette goes into the model's texture blob, where the game points segment 2. Since Fast64 picks CI8 automatically for an image with few enough colors, a model brought in from elsewhere is often paletted already. This is supported and needs no changes.
 
 Large Texture Mode is not supported. It splits a mesh into pieces that each load part of an image, but BK binds a texture whole, by index for a resource and by offset for a `.bin`. Scale the image down to fit TMEM instead.
@@ -221,13 +230,15 @@ The halves are not opaque and translucent geometry sorted by material. What the 
 
 A level's camera gates come in with it, as wire objects in a `<name>_camera_areas` collection. A CAMERA command in the geo layout names one by index and draws what hangs off it only while the camera is inside that box, or outside it. Move a box to move the gate. Delete one and everything it gated stops drawing.
 
-Level Half on the export panel is that tag. Set it on every object in your level, then "Export Level Halves" writes both models in one go. A level brought in with Halves set to Both is already tagged and needs nothing set.
+Level Half on the export panel is that tag, and it reads From Materials until you say otherwise: an object whose materials are all Translucent goes in the translucent half, anything else in the opaque one. Set it outright when you want a piece somewhere its materials don't imply, and the panel says what From Materials worked out for the object you have selected. Then "Export Level Halves" writes both models in one go.
+
+An object with one translucent material among opaque ones stays in the opaque half, since the translucent half writes no depth and could not hide what is behind it. Split it if the two halves need different pieces of it. A level brought in with Halves set to Both is tagged outright and reads nothing off its materials.
 
 The naming is handled for you. A level of your own gets `_OPA` and `_XLU` on the end of its Resource Path. A vanilla level gets the two names the port loads it by, and those differ by more than the suffix: Gobi's Valley is `ASSET_1474_GV_GOBIS_VALLEY_OPA` and `ASSET_1475_GV_GOBIS_VALLEY_XLU`. Point Resource Path at either one and both come out right.
 
 Both halves go out every time, even an empty one, so replacing a level can't leave its old half standing. A half you gave no geometry is written as a model that draws nothing. An opaque only level still gets a translucent model, named from its own asset, for a hack meaning to add one. The map only draws it once its scene definition names an xlu asset.
 
-Default Draw Layer is not that control. Setting it to Translucent will not move faces between halves, it just puts every material you haven't set explicitly onto that layer, opaque geometry included.
+Default Draw Layer is not that control. It says what a material on From Scene renders as, inside whichever half its object is in. Setting it to Translucent doesn't move faces between halves, it just puts every material you haven't set explicitly onto that layer, opaque geometry included.
 
 ### Replacing A Vanilla Model
 To stand in for a vanilla model, your bone table needs to carry the bone IDs that model's animations address. Starting from the original skeleton is much safer than building one from scratch.

--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -230,9 +230,11 @@ The halves are not opaque and translucent geometry sorted by material. What the 
 
 A level's camera gates come in with it, as wire objects in a `<name>_camera_areas` collection. A CAMERA command in the geo layout names one by index and draws what hangs off it only while the camera is inside that box, or outside it. Move a box to move the gate. Delete one and everything it gated stops drawing.
 
-Level Half on the export panel is that tag, and it reads From Materials until you say otherwise: an object whose materials are all Translucent goes in the translucent half, anything else in the opaque one. Set it outright when you want a piece somewhere its materials don't imply, and the panel says what From Materials worked out for the object you have selected. Then "Export Level Halves" writes both models in one go.
+Level Half on the export panel is that tag, and it reads From Materials until you say otherwise. An object whose materials are all one layer goes to that half whole. One holding both is cut along them, its translucent faces to the translucent half and the rest to the opaque one, so a level that came in as a single mesh doesn't have to be separated by hand. The panel says what it worked out for whichever object you have selected. Then "Export Level Halves" writes both models in one go.
 
-An object with one translucent material among opaque ones stays in the opaque half, since the translucent half writes no depth and could not hide what is behind it. Split it if the two halves need different pieces of it. A level brought in with Halves set to Both is tagged outright and reads nothing off its materials.
+A cut duplicates the vertices along the seam, because the two halves are separate models with their own vertex lists and nothing can be shared between them. Vertex groups come through it, so a mesh list spanning the boundary keeps its vertices on both sides.
+
+Set Level Half outright to override the reading, and expect to for a vanilla level. Most of them keep translucent materials in their opaque half, where a face blends and still writes depth, so rebuilding one to its original layout means placing the halves yourself. From Materials sends those faces to the translucent half instead, which is the usual choice for glass and water in a level of your own. A level brought in with Halves set to Both is tagged outright and reads nothing off its materials.
 
 The naming is handled for you. A level of your own gets `_OPA` and `_XLU` on the end of its Resource Path. A vanilla level gets the two names the port loads it by, and those differ by more than the suffix: Gobi's Valley is `ASSET_1474_GV_GOBIS_VALLEY_OPA` and `ASSET_1475_GV_GOBIS_VALLEY_XLU`. Point Resource Path at either one and both come out right.
 

--- a/fast64_internal/hm64/bk64/bk64_anim.py
+++ b/fast64_internal/hm64/bk64/bk64_anim.py
@@ -161,7 +161,10 @@ def _elements(bones, samples, frames, fine, include_rest: bool):
 
     elements.sort(key=lambda element: (element[0], element[1]))
     if len(elements) > ANIM_MAX_ELEMENTS:
-        raise PluginError(f"This animation needs {len(elements)} elements, past the {ANIM_MAX_ELEMENTS} an s16 counts.")
+        raise PluginError(
+            f"This animation fills {len(elements)} bone channels, past the {ANIM_MAX_ELEMENTS} the game "
+            "stores. Animate fewer bones, or fewer channels on each."
+        )
     return elements
 
 

--- a/fast64_internal/hm64/bk64/bk64_collision.py
+++ b/fast64_internal/hm64/bk64/bk64_collision.py
@@ -128,8 +128,8 @@ def collision_grid(triangles, vertices):
                 break
         if scale >= BK_COLLISION_SCALE_MAX:
             raise PluginError(
-                f"{len(points)} collision triangles need a finer grid than a BKCollisionList can "
-                "index. Split the mesh, or take collision off the parts that don't need it."
+                f"{len(points)} collision triangles are more than the game can index. Split the mesh, "
+                "or take collision off the parts that don't need it."
             )
         scale = min(BK_COLLISION_SCALE_MAX, scale + BK_COLLISION_SCALE_STEP)
 

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -309,6 +309,7 @@ MAX_VERTEX_COUNT = 32767  # the header count is an s16, the port drops indices p
 
 # where an imported model's geo layout rides, as JSON on the armature
 GEO_LAYOUT_PROP = "hm64_bk64_geo_layout"
+CAMERA_AREA_KIND = "hm64_bk64_camera_area"  # marks the box objects a geo CAMERA tests against
 
 # an HD image carries the N64 size its tiles address, for the slot to read back
 NATIVE_SIZE_PROP = "hm64_bk64_native_size"

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -332,6 +332,9 @@ SHAPE_KIND = "hm64_bk64_shape"
 SHAPE_PIVOT = "hm64_bk64_shape_pivot"  # the point a box turns about, kept to export it back in place
 COLLISION_ONLY_PROP = "hm64_bk64_collision_only"
 
+# a stand-in root has to carry these, or the section each feeds ships empty
+MODEL_STASH_PROPS = (GEO_LAYOUT_PROP, COLLISION_GRID_PROP)
+
 # what an undrawn collision vertex carried. Nothing reads them, a round trip does.
 COLLISION_COLOR_ATTR = "hm64_bk64_vtx_color"
 COLLISION_UV_ATTR = "hm64_bk64_vtx_uv"

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -100,6 +100,7 @@ MAX_BONE_ID = 0x6C  # the bone transform table is 0x6D entries, indexed by id un
 MAX_LAYOUT_BONE = 127  # the geo layout's BONE command holds its bone index in an s8
 
 MESH_GROUP_PREFIX = "bk64_mesh_"  # the uid rides in the name, it's what the game looks a mesh up by
+MESH_TAG_ATTRIBUTE = "bk64_mesh_tag"  # holds mesh membership through the part and piece splits
 
 GEO_TYPE_MIPMAP_TRILINEAR = 0x02
 

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -297,6 +297,15 @@ def s16(value):
     return max(-32768, min(32767, int(round(value))))
 
 
+def written_key(position, scale_matrix=None):
+    """The Vtx coordinate a point is written at, which binding and mesh lists key by"""
+    # scale then round, the order F3DVert.convertPosition uses. Rounding first
+    # keys a point on a half unit to a coordinate no vertex was written at.
+    if scale_matrix is not None:
+        position = scale_matrix @ position
+    return tuple(s16(value) for value in position)
+
+
 def tri_indices(word, cache):
     """The three vertices a G_TRI word names, or None when a slot holds nothing yet"""
     try:

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -102,6 +102,11 @@ MAX_LAYOUT_BONE = 127  # the geo layout's BONE command holds its bone index in a
 MESH_GROUP_PREFIX = "bk64_mesh_"  # the uid rides in the name, it's what the game looks a mesh up by
 MESH_TAG_ATTRIBUTE = "bk64_mesh_tag"  # holds mesh membership through the part and piece splits
 
+# A mesh's effect comes from which hundred its uid falls in, and uid minus that base
+# is the effect's parameter (core2 func_8034C6DC). For a scroll it is the speed.
+SCROLL_UID_BASE = 100
+MAX_SCROLL_SPEED = 99
+
 GEO_TYPE_MIPMAP_TRILINEAR = 0x02
 
 # A mipmapped chunk renders from the game's own tile pyramid, texture level 2

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -61,6 +61,8 @@ BK_PALETTE_SIZE = {"CI4": 0x20, "CI8": 0x200}
 # for stepping over an image in the model's own texture blob
 BK_TEX_BITS = {"CI4": 4, "CI8": 8, "RGBA16": 16, "RGBA32": 32, "IA8": 8}
 
+TILE_BITS = {0: 4, 1: 8, 2: 16, 3: 32}  # G_SETTILE's siz, the depth the RDP draws at
+
 # slot i of the animated texture list drives this segment, counting down. Each
 # frame the game slides that segment's base on by frame_size bytes.
 SEG_ANIM_BASE = 15

--- a/fast64_internal/hm64/bk64/bk64_geo.py
+++ b/fast64_internal/hm64/bk64/bk64_geo.py
@@ -97,6 +97,8 @@ def relink_layout(records, from_source):
                 out.append(("lod", record[1], record[2], tuple(record[3]), relink(record[4])))
             elif kind == "drawdist":
                 out.append(("drawdist", tuple(record[1]), tuple(record[2]), relink(record[3])))
+            elif kind == "camera":
+                out.append(("camera", list(record[1]), record[2], relink(record[3])))
             elif kind == "refpoint":
                 out.append(("refpoint", record[1], record[2], tuple(record[3])))
             else:

--- a/fast64_internal/hm64/bk64/bk64_geo.py
+++ b/fast64_internal/hm64/bk64/bk64_geo.py
@@ -166,14 +166,16 @@ def geo_records(bones, chunks, armature_obj, rigged: bool, chunk_bounds=None):
             far = getattr(bone, "hm64_bk64_lod_far", 0.0)
             if far <= 0.0:
                 raise PluginError(
-                    f"Bone '{bones[index].name}' is a Level Of Detail with no Far Distance, and would never draw."
+                    f"Bone '{bones[index].name}' is a Level Of Detail with no Far Distance, and would "
+                    "never draw. Set one."
                 )
             return [("lod", far, getattr(bone, "hm64_bk64_lod_near", 0.0), tuple(bones[index].position), records)]
 
         if geo_type == "DRAWDIST":
             if not points:
                 raise PluginError(
-                    f"Bone '{bones[index].name}' is a Draw Distance with no geometry under it to " "make a box from."
+                    f"Bone '{bones[index].name}' is a Draw Distance with no geometry under it to make "
+                    "a box from. Parent geometry to it, or to a bone beneath it."
                 )
             low = tuple(min(point[axis] for point in points) for axis in range(3))
             high = tuple(max(point[axis] for point in points) for axis in range(3))
@@ -189,8 +191,8 @@ def geo_records(bones, chunks, armature_obj, rigged: bool, chunk_bounds=None):
             branches = [subtree(child) for child in children.get(index, [])]
             if len(branches) != 2:
                 raise PluginError(
-                    f"Bone '{bones[index].name}' is a Sort with {len(branches)} child bones, and it "
-                    "orders exactly two."
+                    f"Bone '{bones[index].name}' is a Sort with {len(branches)} child bones. Parent "
+                    "two to it, one per half."
                 )
             middles = []
             for child in children[index]:

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -621,7 +621,10 @@ def _blob_textures(tex_infos):
     for index, info in enumerate(tex_infos):
         otex_format = BK_TEX_FORMAT.get(info["type"])
         if otex_format is None:
-            raise PluginError(f"Texture {index} is type 0x{info['type']:X}, which BK doesn't use.")
+            raise PluginError(
+                f"Texture {index} is type 0x{info['type']:X}, which is none of BK's. Tooie models land "
+                "here, since their texture entries are 8 bytes and lead with the offset, not the type."
+            )
         palette = BK_PALETTE_SIZE[otex_format] if otex_format in PALETTED_FORMATS else 0
         textures.append(
             dict(

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -36,6 +36,7 @@ from .bk64_constants import (
     GEO_CMD_SORT,
     GEO_CMD_TEXWRAP,
     GEO_CMD_UNK0,
+    CAMERA_AREA_KIND,
     GEO_LAYOUT_PROP,
     SOURCE_CHUNK_ATTR,
     MIP_BASE_PROP,
@@ -87,7 +88,7 @@ from .bk64_collision import (
     read_collision,
     read_collision_shapes_data,
 )
-from .bk64_rom import is_bkmodelbin, layout_records, read_bkmodelbin_header
+from .bk64_rom import is_bkmodelbin, layout_records, read_bkmodelbin_header, read_camera_area_list
 from .bk64_skeleton import bone_space_matrix, create_armature_from_bones, read_bone_table
 
 OTEX_FORMAT = {value: key for key, value in OTEX_TYPE.items()}
@@ -154,6 +155,7 @@ def _read_model(data: bytes):
         geo_type=geo_type,
         tri_count=tri_count,
         has_mesh_list=bool(flags[4]),
+        camera_areas=extra["camera_areas"],
         mesh_list=extra["mesh_list"],
         bound_vertices=extra["bound_vertices"],
         animated_textures=extra["animated_textures"],
@@ -201,6 +203,7 @@ def _read_model_bin(data: bytes):
         geo_type=header["geo_type"],
         tri_count=header["tri_count"],
         has_mesh_list=bool(header["mesh_list"]),
+        camera_areas=read_camera_area_list(data, header["camera"], ">", True) if header["camera"] else [],
         mesh_list=_read_mesh_list(data, header["mesh_list"], ">")[0] if header["mesh_list"] else [],
         bound_vertices=(
             _read_bound_vertices(data, header["anim_vertices"], ">", True)[0] if header["anim_vertices"] else []
@@ -282,8 +285,9 @@ def _read_rest(data: bytes, offset: int, flags):
     # landing on the exact end is the only check that the earlier sections were
     # found right. Every one is stepped whether or not it's kept.
     has_camera_areas, has_mesh_list, has_bound_vertices, has_animated_textures = flags
-    extra = dict(mesh_list=[], bound_vertices=[], animated_textures=[])
+    extra = dict(mesh_list=[], bound_vertices=[], animated_textures=[], camera_areas=[])
     if has_camera_areas:
+        extra["camera_areas"] = read_camera_area_list(data, offset)
         offset += 1 + struct.unpack_from("<B", data, offset)[0] * 14
     if has_mesh_list:
         extra["mesh_list"], offset = _read_mesh_list(data, offset)
@@ -1041,6 +1045,31 @@ def _build_collision_only(context, base: str, leftover, vertices, armature_obj, 
     return obj
 
 
+def _build_camera_areas(context, base: str, areas, parent, to_blender):
+    """The boxes a geo CAMERA command gates on, as objects you can move"""
+    collection = bpy.data.collections.new(f"{base}_camera_areas")
+    context.scene.collection.children.link(collection)
+    for index, area in enumerate(areas):
+        low, high = area["min"], area["max"]
+        bm = bmesh.new()
+        bmesh.ops.create_cube(bm, size=1.0)
+        # a flat gate would be invisible and unpickable, so give it a unit of thickness
+        bmesh.ops.scale(bm, vec=[max(abs(high[axis] - low[axis]), 1) for axis in range(3)], verts=bm.verts)
+        mesh = bpy.data.meshes.new(f"{base}_camera_{index:02d}")
+        bm.to_mesh(mesh)
+        bm.free()
+        obj = bpy.data.objects.new(mesh.name, mesh)
+        obj.ignore_render = True  # a gate isn't geometry, it must not export as any
+        obj.display_type = "WIRE"
+        obj[CAMERA_AREA_KIND] = index
+        collection.objects.link(obj)
+        obj.parent = parent
+        context.view_layer.update()
+        centre = mathutils.Vector([(high[axis] + low[axis]) / 2.0 for axis in range(3)])
+        obj.matrix_world = to_blender @ mathutils.Matrix.Translation(centre)
+    return collection
+
+
 def _build_collision_shapes(context, base: str, shapes, armature_obj, mesh_obj, bone_names, to_blender):
     # built around its own origin and placed by its transform, which the export
     # reads it straight back off that
@@ -1242,6 +1271,8 @@ def import_bk64_model(context, path: str, settings):
     # on whichever object the export is handed, the armature when there's one
     (armature_obj or mesh_obj)[GEO_LAYOUT_PROP] = json.dumps(model["geo_layout"])
     (armature_obj or mesh_obj).hm64_bk64_geo_type_raw = model["geo_type"]
+    if model.get("camera_areas"):
+        _build_camera_areas(context, base, model["camera_areas"], armature_obj or mesh_obj, to_blender)
     if model.get("collision_grid"):
         mesh_obj[COLLISION_GRID_PROP] = pack_collision_grid(model["collision_grid"], vertices)
 

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -263,18 +263,6 @@ def _read_bound_vertices(data: bytes, offset: int, endian: str = "<", pad_header
     return entries, offset
 
 
-def _mesh_list_is_exact(meshes, vertices):
-    """Whether a mesh list can be rebuilt from vertex positions alone, as the export does"""
-    owner = {}
-    for entry in meshes:
-        for index in entry["vertices"]:
-            owner[index] = entry["uid"]
-    holders = {}
-    for index, vertex in enumerate(vertices):
-        holders.setdefault(vertex[0], set()).add(owner.get(index))
-    return all(len(held) == 1 for held in holders.values())
-
-
 def _read_animated_textures(data: bytes, offset: int, endian: str):
     """One (frame_size, frame_count, rate) per slot, s16 s16 f32 each"""
     return [struct.unpack_from(endian + "hhf", data, offset + slot * 8) for slot in range(ANIM_TEX_SLOT_COUNT)]
@@ -1316,13 +1304,16 @@ def import_bk64_model(context, path: str, settings):
         else None
     )
 
-    model["mesh_list_exact"] = _mesh_list_is_exact(model["mesh_list"], vertices)
     # the export reads these back by name. A renamed group stops being a mesh.
+    dropped = 0
     for entry in model["mesh_list"]:
-        indices = sorted({remap[orig] for orig in entry["vertices"] if orig in remap})
-        if indices:
+        # vanilla lists vertices no triangle draws, and there is no geometry to put those on
+        drawn = [remap[orig] for orig in entry["vertices"] if orig in remap]
+        dropped += len(entry["vertices"]) - len(drawn)
+        if drawn:
             group = mesh_obj.vertex_groups.new(name=f"{MESH_GROUP_PREFIX}{entry['uid']}")
-            group.add(indices, 1.0, "REPLACE")
+            group.add(sorted(set(drawn)), 1.0, "REPLACE")
+    model["mesh_list_dropped"] = dropped
 
     if armature_obj is not None:
         # a bound model draws under no bone of its own. Its binding table names

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -79,6 +79,7 @@ from .bk64_constants import (
     SEG_TEX_BLOB,
     SHAPE_KIND,
     SHAPE_PIVOT,
+    TILE_BITS,
     tri_indices,
 )
 from .bk64_collision import (
@@ -221,7 +222,12 @@ def _read_model_bin(data: bytes):
         shapes=read_collision_shapes_data(data, header["unk14"], ">")[0] if header["unk14"] else None,
     )
     # the layout is written last and runs to the end of the file
-    return model, vertices, read_geo_body(data[header["geo"] :], ">"), _blob_textures(tex_infos)
+    return (
+        model,
+        vertices,
+        read_geo_body(data[header["geo"] :], ">"),
+        _blob_textures(_retype_ci_from_tiles(words, tex_infos)),
+    )
 
 
 def _read_mesh_list(data: bytes, offset: int, endian: str = "<"):
@@ -597,6 +603,28 @@ def _load_textures(folder: str, base: str, blob: bytes, palettes, used, mip_used
         images[index] = (image, otex_format)
         index += 1
     return images
+
+
+def _retype_ci_from_tiles(words, tex_infos):
+    """tex_infos, with each CI entry's type taken from the tile its image draws from"""
+    drawn_bits, bound = {}, None
+    for w0, w1 in words:
+        if (w0 >> 24) == OP_SETTIMG and (w1 >> 24) == SEG_TEX_BLOB:
+            bound = w1 & 0xFFFFFF
+        elif (w0 >> 24) == OP_SETTILE and (w1 >> 24) == 0 and bound is not None:
+            drawn_bits[bound] = TILE_BITS[(w0 >> 19) & 3]
+            bound = None
+
+    for info in tex_infos:
+        if BK_TEX_FORMAT.get(info["type"]) not in PALETTED_FORMATS:
+            continue
+        for otex_format in ("CI4", "CI8"):
+            # the offset and the depth both have to land, so one alone can't retype
+            image = info["offset"] + BK_PALETTE_SIZE[otex_format]
+            if drawn_bits.get(image) == BK_TEX_BITS[otex_format]:
+                info["type"] = BK_TEX_TYPE[otex_format]
+                break
+    return tex_infos
 
 
 def _blob_textures(tex_infos):

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -1241,6 +1241,7 @@ def import_bk64_model(context, path: str, settings):
     context.scene.collection.objects.link(mesh_obj)
     # on whichever object the export is handed, the armature when there's one
     (armature_obj or mesh_obj)[GEO_LAYOUT_PROP] = json.dumps(model["geo_layout"])
+    (armature_obj or mesh_obj).hm64_bk64_geo_type_raw = model["geo_type"]
     if model.get("collision_grid"):
         mesh_obj[COLLISION_GRID_PROP] = pack_collision_grid(model["collision_grid"], vertices)
 

--- a/fast64_internal/hm64/bk64/bk64_level_models.py
+++ b/fast64_internal/hm64/bk64/bk64_level_models.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 BK64_LEVEL_MODELS = {
@@ -178,6 +179,15 @@ def bk64_level_names() -> list:
     for _, (name, _layer) in sorted(BK64_LEVEL_MODELS.items()):
         seen[name] = None
     return list(seen)
+
+
+def bk64_level_of_asset(path: str):
+    """(level, half) when a file names a level model, else None"""
+    stem = os.path.basename(path).split(".")[0]
+    named = re.fullmatch(r"ASSET_([0-9A-Fa-f]{4})_.+", stem)  # an o2r resource
+    if named is None and not re.fullmatch(r"[0-9A-Fa-f]{4}", stem):  # a decomp asset
+        return None
+    return BK64_LEVEL_MODELS.get(int(named.group(1) if named else stem, 16))
 
 
 def bk64_level_half_paths(resource: str) -> dict:

--- a/fast64_internal/hm64/bk64/bk64_level_models.py
+++ b/fast64_internal/hm64/bk64/bk64_level_models.py
@@ -1,3 +1,5 @@
+import re
+
 BK64_LEVEL_MODELS = {
     0x146B: ("TTC_TREASURE_TROVE_COVE", "OPA"),
     0x146C: ("TTC_TREASURE_TROVE_COVE", "XLU"),
@@ -176,3 +178,20 @@ def bk64_level_names() -> list:
     for _, (name, _layer) in sorted(BK64_LEVEL_MODELS.items()):
         seen[name] = None
     return list(seen)
+
+
+def bk64_level_half_paths(resource: str) -> dict:
+    """{layer: resource path} for both halves, under vanilla's own names where it has them"""
+    head, _, stem = resource.rpartition("/")
+    stem = re.sub(r"_(OPA|XLU)$", "", stem)
+    prefix = f"{head}/" if head else ""
+    # a vanilla level's halves are separate assets, so the ids differ between them
+    named = re.fullmatch(r"ASSET_[0-9A-Fa-f]{4}_(.+)", stem)
+    vanilla = bk64_level_layers(named.group(1)) if named else {}
+    paths = {}
+    for layer in ("OPA", "XLU"):
+        if layer in vanilla:
+            paths[layer] = f"{prefix}ASSET_{vanilla[layer]:04X}_{named.group(1)}_{layer}"
+        else:
+            paths[layer] = f"{prefix}{stem}_{layer}"
+    return paths

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -282,62 +282,177 @@ def promote_materials_to_2_cycle(mesh_obj):
     return changed
 
 
+def armature_of(mesh_obj):
+    """The armature a mesh exports under, or None"""
+    # an ancestor wins over a modifier: the export gathers a model from the root's
+    # children, and a static model parented to an empty carries no modifier at all
+    current = mesh_obj.parent
+    while current is not None:
+        if current.type == "ARMATURE":
+            return current
+        current = current.parent
+    return next((m.object for m in mesh_obj.modifiers if m.type == "ARMATURE" and m.object), None)
+
+
+def checked_armature_of(mesh_obj):
+    """The armature a mesh exports under, refusing one that has none"""
+    armature_obj = armature_of(mesh_obj)
+    if armature_obj is None:
+        raise PluginError(f"'{mesh_obj.name}' is not attached to an armature. Parent it to one.")
+    return armature_obj
+
+
+def bone_groups_of(mesh_obj, armature_obj):
+    """{vertex group index: bone name} for the groups named after a bone"""
+    bone_names = {bone.name for bone in armature_obj.data.bones}
+    return {group.index: group.name for group in mesh_obj.vertex_groups if group.name in bone_names}
+
+
+def checked_bone_groups(mesh_obj, armature_obj):
+    """The bone groups a mesh has, refusing one weighted to no bone"""
+    groups = bone_groups_of(mesh_obj, armature_obj)
+    if not groups:
+        raise PluginError(
+            f"'{mesh_obj.name}' has no vertex groups named after a bone in '{armature_obj.name}'. "
+            "Weight it to the bones you want it to follow."
+        )
+    return groups
+
+
 def select_loose_vertices(mesh_obj):
     """Selects the vertices no bone weights, returning how many"""
     # Select All by Trait finds only the vertices in no group at all, and a
     # weight of 0 or a group no bone is named after reads as loose here too
-    armature_obj = mesh_obj.find_armature()
-    if armature_obj is None:
-        raise PluginError(f"'{mesh_obj.name}' is not attached to an armature.")
+    groups = set(bone_groups_of(mesh_obj, checked_armature_of(mesh_obj)))
 
-    bone_names = {bone.name for bone in armature_obj.data.bones}
-    groups = {group.index for group in mesh_obj.vertex_groups if group.name in bone_names}
-    mesh = mesh_obj.data
+    # bmesh, since writing .select straight onto a from_pydata mesh crashes Blender
+    # 5.0, and every imported model is built that way
+    bm = bmesh.new()
+    bm.from_mesh(mesh_obj.data)
+    try:
+        deform = bm.verts.layers.deform.active
+        # Edit mode flushes from these, and a selected face would bring its corners with it
+        for edge in bm.edges:
+            edge.select = False
+        for face in bm.faces:
+            face.select = False
 
-    # Edit mode flushes from these, and a selected face would bring its corners with it
-    for edge in mesh.edges:
-        edge.select = False
-    for polygon in mesh.polygons:
-        polygon.select = False
-
-    found = 0
-    for vertex in mesh.vertices:
-        vertex.select = not any(entry.group in groups and entry.weight > 0.0 for entry in vertex.groups)
-        found += vertex.select
+        found = 0
+        for vertex in bm.verts:
+            weights = vertex[deform].items() if deform is not None else ()
+            vertex.select = not any(index in groups and weight > 0.0 for index, weight in weights)
+            found += vertex.select
+        bm.to_mesh(mesh_obj.data)
+    finally:
+        bm.free()
+    mesh_obj.data.update()
     return found
+
+
+def source_bones_of(mesh_obj, armature_obj):
+    """{chunk index: bone name} for a model imported with a layout, or None"""
+    stored = stored_layout(armature_obj)
+    if stored is None:
+        stored = stored_layout(mesh_obj)
+    if stored is None:
+        return None
+    # only the names and their order are read back out, so the matrix is free
+    bones = build_bone_table(armature_obj, mathutils.Matrix.Identity(4))[0]
+    return _layout_bone_of_source(stored, bones)[0] or None
+
+
+def bone_of_faces(bm, mesh_obj, group_index_to_bone, fallback_bone_name=None, source_bones=None):
+    """({face: bone name}, how many faces had nothing to vote on)"""
+    source_of_face = _face_sources(mesh_obj.data) if source_bones else []
+    deform_layer = bm.verts.layers.deform.active
+
+    bone_of_face, unweighted = {}, 0
+    for face in bm.faces:
+        bone_name = None
+        if source_bones and face.index < len(source_of_face):
+            bone_name = source_bones.get(source_of_face[face.index])
+        if bone_name is None:
+            group_index = _face_bone_group(face, deform_layer, group_index_to_bone)
+            if group_index is None:
+                unweighted += 1
+            bone_name = group_index_to_bone[group_index] if group_index is not None else fallback_bone_name
+        bone_of_face[face] = bone_name
+    return bone_of_face, unweighted
+
+
+def bone_seam_edges(bm, bone_of_face, armature_obj, source_bones):
+    """Edges whose two faces sit on bones a single chunk cannot span"""
+    parent_of = {bone.name: bone.parent.name if bone.parent else None for bone in armature_obj.data.bones}
+
+    # a chunk carries one bone. A weld across a joint gets torn, except at
+    # a bone and its parent, the one seam skinning blends.
+    def family(name_a, name_b):
+        if name_a is None or name_b is None:
+            return False
+        return parent_of[name_a] == name_b or parent_of[name_b] == name_a
+
+    seams = []
+    for edge in bm.edges:
+        if len(edge.link_faces) != 2:
+            continue
+        name_a, name_b = (bone_of_face[face] for face in edge.link_faces)
+        if name_a != name_b and not (source_bones and family(name_a, name_b)):
+            seams.append(edge)
+    return seams
 
 
 def split_mesh_at_bones(mesh_obj):
     """Cuts a mesh so every triangle belongs to one bone, returning the cut count"""
     # the export needs the mesh this way, but cutting it there would leave the
     # viewport showing something other than what ships
-    armature_obj = next((m.object for m in mesh_obj.modifiers if m.type == "ARMATURE" and m.object), None)
-    if armature_obj is None and mesh_obj.parent is not None and mesh_obj.parent.type == "ARMATURE":
-        armature_obj = mesh_obj.parent
-    if armature_obj is None:
-        raise PluginError(f"'{mesh_obj.name}' is not attached to an armature.")
-
-    bone_names = {bone.name for bone in armature_obj.data.bones}
-    groups = {group.index: group.name for group in mesh_obj.vertex_groups if group.name in bone_names}
-    if not groups:
-        raise PluginError(f"'{mesh_obj.name}' has no vertex groups named after a bone in '{armature_obj.name}'.")
+    armature_obj = checked_armature_of(mesh_obj)
+    groups = checked_bone_groups(mesh_obj, armature_obj)
 
     bm = bmesh.new()
     bm.from_mesh(mesh_obj.data)
     deform = bm.verts.layers.deform.verify()
 
-    # the same rule the export uses, or a mesh cut here still reads as welded there
+    # every weight boundary. The export reads which bone a vertex follows off the
+    # weights, and only one bone per vertex lets it find the parent's vertices.
     owners = {face: _face_bone_group(face, deform, groups) for face in bm.faces}
-
     seams = [edge for edge in bm.edges if len({owners[f] for f in edge.link_faces}) > 1]
-    # use_verts also separates where two bones meet at a single vertex
+
+    # then the boundaries only the layout knows about. The weights alone can
+    # disagree with it, and the export counts a weld they called clean.
+    source_bones = source_bones_of(mesh_obj, armature_obj)
+    if source_bones:
+        by_layout = bone_of_faces(bm, mesh_obj, groups, None, source_bones)[0]
+        already = {edge.index for edge in seams}
+        layout_seams = bone_seam_edges(bm, by_layout, armature_obj, source_bones)
+        seams += [edge for edge in layout_seams if edge.index not in already]
+
+    # use_verts splits the vertices along these edges as well
     bmesh.ops.split_edges(bm, edges=seams, use_verts=True)
+
+    # a vertex the seams did not separate can still hold faces from two bones. The
+    # rewrite below would give it to whichever comes last, so cut those apart first.
+    conflicted = set()
+    for vert in bm.verts:
+        holding = {owners.get(face) for face in vert.link_faces}
+        if len(holding) > 1:
+            conflicted |= holding
+    # in face order: reordering these splits cost one vanilla model its skinning,
+    # so which copy of a shared vertex each chunk keeps is load bearing
+    faces_by_owner = {}
+    for face, owner in owners.items():
+        if owner in conflicted:
+            faces_by_owner.setdefault(owner, []).append(face)
+    for faces in faces_by_owner.values():
+        bmesh.ops.split(bm, geom=faces, use_only_faces=False)
+
     for face in bm.faces:
         owner = owners.get(face)
         if owner is None:
             continue
         for vert in face.verts:
-            vert[deform].clear()
+            # only the bone groups. Clearing the lot takes the mesh groups with it.
+            for index in [i for i in vert[deform].keys() if i in groups]:
+                del vert[deform][index]
             vert[deform][owner] = 1.0
 
     bm.to_mesh(mesh_obj.data)
@@ -360,28 +475,11 @@ def _face_bone_group(face, deform_layer, group_index_to_bone):
 
 
 def _split_mesh_by_bone(context, bm, mesh_obj, armature_obj, fallback_bone_name: str, source_bones=None, warnings=None):
-    bone_names = {bone.name for bone in armature_obj.data.bones}
-    group_index_to_bone = {group.index: group.name for group in mesh_obj.vertex_groups if group.name in bone_names}
-    if not group_index_to_bone:
-        raise PluginError(f"'{mesh_obj.name}' has no vertex groups matching a bone in '{armature_obj.name}'.")
+    group_index_to_bone = checked_bone_groups(mesh_obj, armature_obj)
 
-    # an imported face keeps its chunk's bone from the layout, not a weight
-    # vote that could land it across the seam
-    source_of_face = _face_sources(mesh_obj.data) if source_bones else []
-
-    deform_layer = bm.verts.layers.deform.active
-    bone_of_face, faces_by_bone = {}, {}
-    unweighted = 0
-    for face in bm.faces:
-        bone_name = None
-        if source_bones and face.index < len(source_of_face):
-            bone_name = source_bones.get(source_of_face[face.index])
-        if bone_name is None:
-            group_index = _face_bone_group(face, deform_layer, group_index_to_bone)
-            if group_index is None:
-                unweighted += 1
-            bone_name = group_index_to_bone[group_index] if group_index is not None else fallback_bone_name
-        bone_of_face[face] = bone_name
+    bone_of_face, unweighted = bone_of_faces(bm, mesh_obj, group_index_to_bone, fallback_bone_name, source_bones)
+    faces_by_bone = {}
+    for face, bone_name in bone_of_face.items():
         faces_by_bone.setdefault(bone_name, []).append(face.index)
 
     # a face with nothing to vote on lands on the root, right for scenery and wrong for a limb
@@ -391,21 +489,17 @@ def _split_mesh_by_bone(context, bm, mesh_obj, armature_obj, fallback_bone_name:
             f"and went onto '{fallback_bone_name}'."
         )
 
-    # a chunk carries one bone. A weld across a joint gets torn, except at
-    # a bone and its parent, the one seam skinning blends.
-    def family(name_a, name_b):
-        bone_a, bone_b = armature_obj.data.bones[name_a], armature_obj.data.bones[name_b]
-        return bone_a.parent == bone_b or bone_b.parent == bone_a
-
-    seams = sum(
-        1
-        for edge in bm.edges
-        if len(edge.link_faces) == 2
-        and bone_of_face[edge.link_faces[0]] != bone_of_face[edge.link_faces[1]]
-        and not (source_bones and family(bone_of_face[edge.link_faces[0]], bone_of_face[edge.link_faces[1]]))
-    )
+    seams = bone_seam_edges(bm, bone_of_face, armature_obj, source_bones)
     if seams:
-        raise PluginError(f"'{mesh_obj.name}' is welded across {seams} bone boundaries. Run Split Mesh At Bones.")
+        bones = sorted({bone_of_face[face] or "no bone" for edge in seams for face in edge.link_faces})
+        where = ", ".join(bones[:4]) + (f" and {len(bones) - 4} more" if len(bones) > 4 else "")
+        # Split Mesh At Bones cuts the mesh itself, and this reads it with its modifiers
+        # applied. Telling someone to run a cut they already ran helps nobody.
+        if len(bm.verts) != len(mesh_obj.data.vertices):
+            fix = "Apply its modifiers first, they make geometry Split Mesh At Bones never saw."
+        else:
+            fix = "Run Split Mesh At Bones."
+        raise PluginError(f"'{mesh_obj.name}' is welded across {len(seams)} bone boundaries, at {where}. {fix}")
 
     parts = {}
     for bone_name, face_indices in faces_by_bone.items():

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -1058,9 +1058,22 @@ def _gather_parts(
 LEVEL_HALVES = (("OPAQUE", "_OPA"), ("TRANSLUCENT", "_XLU"))
 
 
+def level_half_of(mesh_obj):
+    """The half an object belongs to, reading its materials when it hasn't been told"""
+    chosen = mesh_obj.hm64_bk64_level_half
+    if chosen != "AUTO":
+        return chosen
+    materials = [slot.material for slot in mesh_obj.material_slots if slot.material is not None]
+    # every one of them, since the translucent half cannot hide what is behind it
+    translucent = materials and all(
+        getattr(material, "hm64_bk64_draw_layer", "SCENE").startswith("TRANSLUCENT") for material in materials
+    )
+    return "TRANSLUCENT" if translucent else "OPAQUE"
+
+
 def level_half_objects(mesh_objects, half: str):
-    """The meshes marked for this half"""
-    return [obj for obj in mesh_objects if obj.hm64_bk64_level_half == half]
+    """The meshes that belong to this half"""
+    return [obj for obj in mesh_objects if level_half_of(obj) == half]
 
 
 def blank_half_object(context, mesh_objects, half: str, temp_objects):

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -36,6 +36,7 @@ from .bk64_constants import (
     COLLISION_GRID_PROP,
     COLLISION_ONLY_PROP,
     COLLISION_UV_ATTR,
+    CAMERA_AREA_KIND,
     SOURCE_CHUNK_ATTR,
     CYCLE_TYPE_2CYCLE,
     DEFAULT_LIGHT_DIR,
@@ -92,6 +93,7 @@ from .bk64_rom import (
     collision_shapes,
     geo_body,
     layout_records,
+    camera_area_list,
     mesh_list,
     vertex_bone_map,
     vertex_records,
@@ -152,6 +154,7 @@ def _write_model_resource(
     tex_blob,
     collision,
     shapes,
+    camera_areas,
     bound_vertices,
     meshes,
     animated_slots,
@@ -171,7 +174,7 @@ def _write_model_resource(
             1 if has_anim else 0,
             1 if collision else 0,
             1 if shapes else 0,
-            0,  # camera areas
+            1 if camera_areas else 0,
             1 if meshes else 0,
             1 if bound_vertices else 0,
             1 if any(slot[0] for slot in animated_slots) else 0,
@@ -207,6 +210,8 @@ def _write_model_resource(
         data.extend(write_collision_list(collision, vertices, collision_grid_stored, "<"))
     if shapes:
         data.extend(collision_shapes(shapes))
+    if camera_areas:
+        data.extend(camera_area_list(camera_areas))
     if meshes:
         data.extend(mesh_list(meshes))
     if bound_vertices:
@@ -520,6 +525,22 @@ def _to_bk_space(root_obj, scale: float):
         else root_obj.matrix_world.inverted()
     )
     return BLENDER_TO_BK @ mathutils.Matrix.Diagonal(mathutils.Vector((scale, scale, scale))).to_4x4() @ origin
+
+
+def read_camera_areas(root_obj, scale: float):
+    """The camera gate boxes under the root, as the unk20 section wants them"""
+    to_bk = _to_bk_space(root_obj, scale)
+    areas = []
+    for obj in root_obj.children_recursive:
+        index = obj.get(CAMERA_AREA_KIND)
+        if index is None or obj.type != "MESH":
+            continue
+        corners = [to_bk @ obj.matrix_world @ mathutils.Vector(corner) for corner in obj.bound_box]
+        low = [s16(min(corner[axis] for corner in corners)) for axis in range(3)]
+        high = [s16(max(corner[axis] for corner in corners)) for axis in range(3)]
+        areas.append((index, dict(min=low, max=high)))
+    # the geo CAMERA commands address these by index, so the order is not cosmetic
+    return [area for _index, area in sorted(areas, key=lambda pair: pair[0])]
 
 
 def read_collision_shapes(root_obj, scale: float):
@@ -1222,6 +1243,10 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
             for key, value in fModel.materials.items()
             if getattr(f3d_settings(key[0]).rdp_settings, "g_tex_gen", False)
         }
+        # the geo CAMERA commands come back with the layout, and cull everything
+        # they gate when the boxes they test against are missing
+        camera_areas = read_camera_areas(root_obj, settings.scale)
+
         vertices, mesh_tags, vertex_owners, spans = _collect_vertices(
             ordered_fMeshes, shade_colors, settings.force_unlit, reflective
         )
@@ -1374,6 +1399,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
                     vertices,
                     collision,
                     shapes,
+                    camera_areas,
                     bound_vertices,
                     meshes,
                     slot_table,
@@ -1394,6 +1420,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
                 tex_blob,
                 collision,
                 shapes,
+                camera_areas,
                 bound_vertices,
                 meshes,
                 slot_table,

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -1060,22 +1060,79 @@ def _gather_parts(
 LEVEL_HALVES = (("OPAQUE", "_OPA"), ("TRANSLUCENT", "_XLU"))
 
 
-def level_half_of(mesh_obj):
-    """The half an object belongs to, reading its materials when it hasn't been told"""
+def _material_half(material):
+    """The half a material's draw layer puts its faces in"""
+    layer = getattr(material, "hm64_bk64_draw_layer", "SCENE") if material is not None else "SCENE"
+    return "TRANSLUCENT" if layer.startswith("TRANSLUCENT") else "OPAQUE"
+
+
+def level_half_faces(mesh_obj, half: str):
+    """The faces of an object that belong in this half, or None when they all do"""
+    halves = [_material_half(slot.material) for slot in mesh_obj.material_slots]
+    if not halves:  # nothing to read a layer off, so it draws solid
+        return None if half == "OPAQUE" else []
+    if all(each == half for each in halves):
+        return None
+    if not any(each == half for each in halves):
+        return []
+    return [face.index for face in mesh_obj.data.polygons if halves[face.material_index] == half]
+
+
+def whole_level_half(mesh_obj):
+    """Where an object goes when it can't be cut, since no draw layer places it"""
+    chosen = mesh_obj.hm64_bk64_level_half
+    return "OPAQUE" if chosen == "AUTO" else chosen
+
+
+def in_level_half(mesh_obj, half: str) -> bool:
+    """Whether an object reaches this half, off its materials rather than its faces"""
     chosen = mesh_obj.hm64_bk64_level_half
     if chosen != "AUTO":
-        return chosen
-    materials = [slot.material for slot in mesh_obj.material_slots if slot.material is not None]
-    # every one of them, since the translucent half cannot hide what is behind it
-    translucent = materials and all(
-        getattr(material, "hm64_bk64_draw_layer", "SCENE").startswith("TRANSLUCENT") for material in materials
-    )
-    return "TRANSLUCENT" if translucent else "OPAQUE"
+        return chosen == half
+    halves = [_material_half(slot.material) for slot in mesh_obj.material_slots]
+    # a slot no face uses still counts, since a panel asks this on every redraw
+    # and walking the faces there would crawl
+    return half in halves if halves else half == "OPAQUE"
 
 
-def level_half_objects(mesh_objects, half: str):
-    """The meshes that belong to this half"""
-    return [obj for obj in mesh_objects if level_half_of(obj) == half]
+def _faces_as_object(context, mesh_obj, faces, half: str, temp_objects):
+    """A copy of the object holding only these faces"""
+    # copied rather than rebuilt, so the vertex groups a mesh list rides in
+    # and everything else on the object come with it
+    copy = mesh_obj.copy()
+    copy.data = mesh_obj.data.copy()
+    copy.name = f"{mesh_obj.name}_{half.lower()}"
+    context.scene.collection.objects.link(copy)
+    temp_objects.append(copy)
+
+    bm = bmesh.new()
+    try:
+        bm.from_mesh(copy.data)
+        bm.faces.ensure_lookup_table()
+        keep = set(faces)
+        bmesh.ops.delete(bm, geom=[f for f in bm.faces if f.index not in keep], context="FACES")
+        bm.to_mesh(copy.data)
+    finally:
+        bm.free()
+    copy.data.calc_loop_triangles()
+    return copy
+
+
+def level_half_objects(context, mesh_objects, half: str, temp_objects):
+    """The meshes to export for this half, cutting a mixed one along its materials"""
+    parts = []
+    for mesh_obj in mesh_objects:
+        chosen = mesh_obj.hm64_bk64_level_half
+        if chosen != "AUTO":
+            if chosen == half:
+                parts.append(mesh_obj)
+            continue
+        faces = level_half_faces(mesh_obj, half)
+        if faces is None:
+            parts.append(mesh_obj)
+        elif faces:
+            parts.append(_faces_as_object(context, mesh_obj, faces, half, temp_objects))
+    return parts
 
 
 def blank_half_object(context, mesh_objects, half: str, temp_objects):

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -2,24 +2,19 @@ from __future__ import annotations
 
 import math
 import struct
-import zlib
 
 import bmesh
 import bpy
 import mathutils
 
 from ...f3d.f3d_gbi import (
-    FImage,
     FPaletteKey,
     VTX_SIZE,
     DLFormat,
     FModel,
     GfxMatWriteMethod,
-    SPDisplayList,
-    SPEndDisplayList,
     SPTexture,
 )
-from ...f3d.f3d_material import get_output_method
 from ...f3d.f3d_writer import TriangleConverterInfo, getInfoDict, saveStaticModel
 from ...utility import (
     PluginError,
@@ -518,7 +513,7 @@ def _to_bk_space(root_obj, scale: float):
     return BLENDER_TO_BK @ mathutils.Matrix.Diagonal(mathutils.Vector((scale, scale, scale))).to_4x4() @ origin
 
 
-def read_camera_areas(root_obj, scale: float):
+def read_camera_areas(root_obj, scale: float, warnings=None):
     """The camera gate boxes under the root, as the unk20 section wants them"""
     to_bk = _to_bk_space(root_obj, scale)
     areas = []
@@ -531,7 +526,14 @@ def read_camera_areas(root_obj, scale: float):
         high = [s16(max(corner[axis] for corner in corners)) for axis in range(3)]
         areas.append((index, dict(min=low, max=high)))
     # the geo CAMERA commands address these by index, so the order is not cosmetic
-    return [area for _index, area in sorted(areas, key=lambda pair: pair[0])]
+    areas.sort(key=lambda pair: pair[0])
+    numbered = [index for index, _area in areas]
+    if warnings is not None and numbered != list(range(len(numbered))):
+        warnings.append(
+            f"The camera gate boxes are numbered {numbered}, and the layout addresses them as "
+            f"0 to {len(numbered) - 1}. Renumber them, or the wrong geometry is gated."
+        )
+    return [area for _index, area in areas]
 
 
 def read_collision_shapes(root_obj, scale: float):
@@ -1284,7 +1286,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
         }
         # the geo CAMERA commands come back with the layout, and cull everything
         # they gate when the boxes they test against are missing
-        camera_areas = read_camera_areas(root_obj, settings.scale)
+        camera_areas = read_camera_areas(root_obj, settings.scale, settings.warnings)
 
         vertices, mesh_tags, vertex_owners, spans = _collect_vertices(
             ordered_fMeshes, shade_colors, settings.force_unlit, reflective
@@ -1384,6 +1386,12 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
                 )
             vertices += [(position, 0, uv, color) for position, uv, color in hidden_vertices]
             collision += [((base + a, base + b, base + c), flags, unk6) for a, b, c, flags, unk6 in hidden_surfaces]
+
+        if len(vertices) > MAX_VERTEX_COUNT:
+            raise PluginError(
+                f"{len(vertices)} vertices is past the {MAX_VERTEX_COUNT} the game can index. "
+                "Simplify the mesh, or split it across more than one model."
+            )
 
         # after the append, the way vanilla does it. global_norm is the radius
         # collision gets tested against at all

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -42,6 +42,7 @@ from .bk64_constants import (
     MAX_DRAWABLE_BONE_INDEX,
     MAX_VERTEX_COUNT,
     MESH_GROUP_PREFIX,
+    MESH_TAG_ATTRIBUTE,
     MIP_SPTEXTURE_LEVEL,
     MIP_SPTEXTURE_TILE,
     MIP_TEXTURE_DIM,
@@ -902,31 +903,48 @@ def _checked_mesh_uid(group):
     return uid
 
 
-def _mesh_list_positions(context, mesh_objects, space_matrix, scale_matrix):
-    """{written position: {mesh uid}} from the meshes' own mesh list groups"""
-    at_position = {}
-    for key, held in _grouped_vertices(context, mesh_objects, space_matrix, scale_matrix, _checked_mesh_uid):
-        at_position.setdefault(key, set()).update(uid for uid, _weight in held)
-    return at_position
+def _tag_mesh_groups(bm, mesh_obj, index_of):
+    """Write each vertex's mesh membership into the bmesh, as an index into index_of"""
+    uid_of_group = {}
+    for group in mesh_obj.vertex_groups:
+        uid = _checked_mesh_uid(group)
+        if uid is not None:
+            uid_of_group[group.index] = uid
+    if not uid_of_group:
+        return
+
+    deform = bm.verts.layers.deform.active
+    if deform is None:
+        return
+    layer = bm.verts.layers.int.get(MESH_TAG_ATTRIBUTE) or bm.verts.layers.int.new(MESH_TAG_ATTRIBUTE)
+    for vertex in bm.verts:
+        held = frozenset(
+            uid_of_group[index] for index, weight in vertex[deform].items() if index in uid_of_group and weight > 0.0
+        )
+        # every vertex, since index 0 is the empty set and a stale layer would show through
+        vertex[layer] = index_of.setdefault(held, len(index_of))
 
 
-def _mesh_list_entries(vertices, uids_at_position):
-    """One mesh per uid, listing every vertex written at its coordinates"""
-    order, holding = [], {}
-    for index, vertex in enumerate(vertices):
-        key = _written_key(vertex[0])
-        for uid in sorted(uids_at_position.get(key, ())):
-            if uid not in holding:
-                order.append(uid)
-                holding[uid] = []
-            holding[uid].append(index)
-    return [dict(uid=uid, vertices=holding[uid]) for uid in order]
+def _piece_mesh_tags(piece):
+    """One tag per source vertex, or None when the piece has none"""
+    attribute = piece.data.attributes.get(MESH_TAG_ATTRIBUTE)
+    return [item.value for item in attribute.data] if attribute else None
+
+
+def _mesh_list_entries(tags, uid_sets):
+    """One mesh per uid, listing every vertex the export wrote for it"""
+    holding = {}
+    for index, tag in enumerate(tags):
+        for uid in uid_sets[tag]:
+            holding.setdefault(uid, []).append(index)
+    # every vanilla mesh list runs in ascending uid
+    return [dict(uid=uid, vertices=holding[uid]) for uid in sorted(holding)]
 
 
 def _collect_vertices(fMeshes, shade_colors, force_unlit: bool, reflective=frozenset()):
     # startAddress is a byte offset, so SPVertex.to_binary emits the segment 1
     # address directly and nothing needs patching after
-    vertices, owners, spans = [], [], {}
+    vertices, tags, owners, spans = [], [], [], {}
     for fMesh in fMeshes:
         spans[id(fMesh)] = len(vertices)
         for triGroup in fMesh.triangleGroups:
@@ -944,9 +962,10 @@ def _collect_vertices(fMeshes, shade_colors, force_unlit: bool, reflective=froze
                     else tuple(vtx.colorOrNormal)
                 )
                 vertices.append((tuple(vtx.position), vtx.packedNormal, tuple(vtx.uv), color))
+                tags.append(vtx.meshTag or 0)  # 0 is the empty set, which a model with no meshes writes
             owners.append((first, len(vertices), id(triGroup.fMaterial)))
         spans[id(fMesh)] = (spans[id(fMesh)], len(vertices))
-    return vertices, owners, spans
+    return vertices, tags, owners, spans
 
 
 def _layout_bone_of_source(records, bones):
@@ -979,7 +998,8 @@ def _gather_parts(
     source_bones=None,
     warnings=None,
 ):
-    """Groups the geometry by bone name, building the temporary meshes"""
+    """(bone table, parts by bone name, the uid sets the vertex tags index into)"""
+    mesh_uids = {frozenset(): 0}
     # bind rigging skips the grouping, its vertices carry the rig instead
     if armature_obj is None or bind:
         # one implicit bone, same code path builds the chunks
@@ -992,13 +1012,14 @@ def _gather_parts(
         for mesh_obj in mesh_objects:
             bm = _evaluated_bmesh(context, mesh_obj, to_bk_space, bind)
             try:
+                _tag_mesh_groups(bm, mesh_obj, mesh_uids)
                 part = _bmesh_to_object(context, bm, f"bk64_{mesh_obj.name}", mesh_obj)
             finally:
                 bm.free()
             if part is not None:
                 temp_objects.append(part)
                 meshes_by_bone[holder].append(part)
-        return bones, meshes_by_bone
+        return bones, meshes_by_bone, mesh_uids
 
     bones, _index_of_name = build_bone_table(armature_obj, bone_matrix)
     root_bone_name = bones[0].name
@@ -1006,6 +1027,7 @@ def _gather_parts(
     for mesh_obj in mesh_objects:
         bm = _evaluated_bmesh(context, mesh_obj, to_bk_space, True)
         try:
+            _tag_mesh_groups(bm, mesh_obj, mesh_uids)
             if mesh_obj.parent_type == "BONE" and mesh_obj.parent_bone:
                 part = _bmesh_to_object(context, bm, f"bk64_{mesh_obj.name}", mesh_obj)
                 if part is not None:
@@ -1018,7 +1040,7 @@ def _gather_parts(
                 meshes_by_bone.setdefault(bone_name, []).extend(parts)
         finally:
             bm.free()
-    return bones, meshes_by_bone
+    return bones, meshes_by_bone, mesh_uids
 
 
 def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=None):
@@ -1069,7 +1091,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
         if stored is not None and rigged:  # only a split mesh gets cut along these
             table = build_bone_table(armature_obj, bone_matrix)[0]
             source_bones, source_parents = _layout_bone_of_source(stored, table)
-        bones, meshes_by_bone = _gather_parts(
+        bones, meshes_by_bone, mesh_uids = _gather_parts(
             context,
             root_obj,
             mesh_objects,
@@ -1098,7 +1120,9 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
             for part in parts:
                 for layer, piece in _split_by_draw_key(context, part, settings.draw_layer, temp_objects):
                     infoDict = getInfoDict(piece)
-                    triConverterInfo = TriangleConverterInfo(piece, None, fModel.f3d, transform_matrix, infoDict)
+                    triConverterInfo = TriangleConverterInfo(
+                        piece, None, fModel.f3d, transform_matrix, infoDict, _piece_mesh_tags(piece)
+                    )
                     fMeshes = saveStaticModel(
                         triConverterInfo,
                         fModel,
@@ -1194,7 +1218,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
             for key, value in fModel.materials.items()
             if getattr(f3d_settings(key[0]).rdp_settings, "g_tex_gen", False)
         }
-        vertices, vertex_owners, spans = _collect_vertices(
+        vertices, mesh_tags, vertex_owners, spans = _collect_vertices(
             ordered_fMeshes, shade_colors, settings.force_unlit, reflective
         )
         if not vertices:
@@ -1264,9 +1288,8 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
                 for shape in shapes[group]:
                     shape["bone"] = index_of_bone.get(shape.pop("bone_name"), -1)
 
-        # both of these match on position. Take them before the collision only
-        # vertices land, or one sitting on a drawn vertex joins its binding
-        # entry and its mesh.
+        # binding matches on position. Take it before the collision only vertices
+        # land, or one sitting on a drawn vertex joins its entry.
         bound_vertices = (
             _vertex_bone_entries(vertices, owner_of_pos, settings.warnings, transform_matrix @ to_bk_space)
             if bind
@@ -1275,9 +1298,13 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
         if bind and not bound_vertices:
             raise PluginError(f"Bind Vertices found nothing to bind. Weight the mesh to '{root_obj.name}'.")
 
-        meshes = _mesh_list_entries(
-            vertices, _mesh_list_positions(context, mesh_objects, to_bk_space, transform_matrix)
-        )
+        meshes = _mesh_list_entries(mesh_tags, sorted(mesh_uids, key=mesh_uids.get))
+        lost = sorted({uid for held in mesh_uids for uid in held} - {entry["uid"] for entry in meshes})
+        if lost:
+            settings.warnings.append(
+                f"Mesh {', '.join(str(uid) for uid in lost)} has no drawn faces and was left out of the "
+                "mesh list. Give the group faces, or delete it."
+            )
 
         if collision_only is not None:
             hidden_vertices, hidden_surfaces = collision_only

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -39,6 +39,7 @@ from .bk64_constants import (
     SOURCE_CHUNK_ATTR,
     CYCLE_TYPE_2CYCLE,
     DEFAULT_LIGHT_DIR,
+    GEO_TYPE_MIPMAP_TRILINEAR,
     MAX_DRAWABLE_BONE_INDEX,
     MAX_VERTEX_COUNT,
     MESH_GROUP_PREFIX,
@@ -1168,7 +1169,10 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
                     for command in gfx_list.commands:
                         if isinstance(command, SPTexture):
                             command.on = 0
-        if settings.mipmap and not rom_format:
+        # an import stores geo type on the object, since a level's halves disagree
+        geo_type = root_obj.hm64_bk64_geo_type_raw or settings.geo_type_bits()
+        # the bits shipped, not the scene setting: a level's second half clears that
+        if (geo_type & GEO_TYPE_MIPMAP_TRILINEAR) and not rom_format:
             for key, value in fModel.materials.items():
                 material = key[0]
                 f3d_mat = f3d_settings(material)
@@ -1358,7 +1362,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
         if rom_format:
             return {
                 "": write_bkmodelbin(
-                    settings.geo_type_bits(),
+                    geo_type,
                     count_triangles(dl_words),
                     bounds,
                     dl_words,
@@ -1379,7 +1383,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
 
         resources = {
             "": _write_model_resource(
-                settings.geo_type_bits(),
+                geo_type,
                 count_triangles(dl_words),
                 bounds,
                 dl_words,

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -1065,6 +1065,41 @@ def _gather_parts(
     return bones, meshes_by_bone, mesh_uids
 
 
+# a level's two models in draw order, the opaque one writing depth and the
+# translucent one only testing against it
+LEVEL_HALVES = (("OPAQUE", "_OPA"), ("TRANSLUCENT", "_XLU"))
+
+
+def level_half_objects(mesh_objects, half: str):
+    """The meshes marked for this half"""
+    return [obj for obj in mesh_objects if obj.hm64_bk64_level_half == half]
+
+
+def blank_half_object(context, mesh_objects, half: str, temp_objects):
+    """A model that draws nothing, for the half with no geometry of its own"""
+    material = next(
+        (slot.material for obj in mesh_objects for slot in obj.material_slots if slot.material is not None),
+        None,
+    )
+    if material is None:
+        raise PluginError("Nothing to build a blank half from. Give the level's geometry a material.")
+
+    name = f"bk64_blank_{half.lower()}"
+    mesh = bpy.data.meshes.new(name)
+    # the export refuses an empty mesh, so this is one triangle with no area
+    mesh.from_pydata([(0.0, 0.0, 0.0)] * 3, [], [(0, 1, 2)])
+    mesh.update()
+    mesh.uv_layers.new(name="UVMap")
+    mesh.materials.append(material)
+
+    blank = bpy.data.objects.new(name, mesh)
+    blank.use_f3d_culling = False
+    context.scene.collection.objects.link(blank)
+    temp_objects.append(blank)
+    mesh.calc_loop_triangles()
+    return blank
+
+
 def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=None):
     """Builds the whole resource family as {suffix: bytes}.
 

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import math
 import struct
 import zlib
@@ -60,6 +59,7 @@ from .bk64_constants import (
     SEG_VTX,
     SHAPE_KIND,
     SHAPE_PIVOT,
+    written_key,
 )
 from .bk64_texture import (
     animated_slots,
@@ -96,6 +96,7 @@ from .bk64_rom import (
     camera_area_list,
     mesh_list,
     vertex_bone_map,
+    vertex_bounds,
     vertex_records,
     write_bkmodelbin,
 )
@@ -181,17 +182,7 @@ def _write_model_resource(
         )
     )
 
-    data.extend(
-        struct.pack(
-            "<hhhhhhhhhhHh",
-            *(s16(value) for value in bounds["min"]),
-            *(s16(value) for value in bounds["max"]),
-            *(s16(value) for value in bounds["center"]),
-            s16(bounds["local_norm"]),
-            bounds["count"],
-            s16(bounds["global_norm"]),
-        )
-    )
+    data.extend(vertex_bounds(bounds))
 
     data.extend(struct.pack("<III", len(dl_words), 0, gfx_sub_count))
     for w0, w1 in dl_words:
@@ -826,15 +817,6 @@ def _shade_from_normal(packed, ambient, sources):
     return tuple(min(255, int(round(channel))) for channel in shade) + (255,)
 
 
-def _written_key(position, scale_matrix=None):
-    """The Vtx coordinate a point is written at, which binding and mesh lists key by"""
-    # scale then round, the order F3DVert.convertPosition uses. Rounding first
-    # keys a point on a half unit to a coordinate no vertex was written at.
-    if scale_matrix is not None:
-        position = scale_matrix @ position
-    return tuple(s16(value) for value in position)
-
-
 def _grouped_vertices(context, mesh_objects, space_matrix, scale_matrix, value_of):
     """(written position, [(value, weight)]) for every vertex in a group value_of names.
 
@@ -861,7 +843,7 @@ def _grouped_vertices(context, mesh_objects, space_matrix, scale_matrix, value_o
                     if index in groups and weight > 0.0
                 ]
                 if held:
-                    yield _written_key(vertex.co, scale_matrix), held
+                    yield written_key(vertex.co, scale_matrix), held
         finally:
             bm.free()
 
@@ -885,7 +867,7 @@ def _vertex_bone_entries(vertices, bound, warnings, space_matrix):
     at_position = {}
     loose = set()
     for index, vertex in enumerate(vertices):
-        key = _written_key(vertex[0])
+        key = written_key(vertex[0])
         if key in bound:
             at_position.setdefault(key, []).append(index)
         else:

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -663,14 +663,17 @@ def read_collision_only(context, root_obj, scale: float):
 
 
 def _check_cycle_type(mesh_objects):
-    """BK draws models in 2 cycle and a 1 cycle material renders black"""
+    """BK draws models in 2 cycle, and a 1 cycle material never reaches the blending"""
     offenders = []
     for material, f3d_mat in f3d_materials(mesh_objects):
         if f3d_mat.rdp_settings.g_mdsft_cycletype != CYCLE_TYPE_2CYCLE and material.name not in offenders:
             offenders.append(material.name)
     if offenders:
         listed = "\n  ".join(offenders)
-        raise PluginError(f"BK draws models in 2 cycle and these would render black. Set Cycle Type:\n  {listed}")
+        raise PluginError(
+            "BK draws models in 2 cycle, and these would lose the blending the second cycle does. "
+            f"Set Cycle Type:\n  {listed}"
+        )
 
 
 def _check_large_textures(mesh_objects):
@@ -921,7 +924,10 @@ def _checked_mesh_uid(group):
     """The mesh uid a group names, refusing one the section can't store"""
     uid = _mesh_group_uid(group.name)
     if uid is not None and not -0x8000 <= uid <= 0x7FFF:
-        raise PluginError(f"Vertex group '{group.name}' names mesh {uid}, past the s16 BKMesh.uid holds.")
+        raise PluginError(
+            f"Vertex group '{group.name}' names mesh {uid}, which is out of range. "
+            "Rename it to a number from -32768 to 32767."
+        )
     return uid
 
 
@@ -1124,10 +1130,13 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
     _check_cycle_type(mesh_objects)
     check_camera_water_reads(mesh_objects, settings.warnings)
     _check_large_textures(mesh_objects)
-    culling = [obj.name for obj in mesh_objects if obj.use_f3d_culling]
+    # nothing in BK reads a cull list, and the import and the splitter already clear it
+    culling = [obj for obj in mesh_objects if obj.use_f3d_culling]
+    for obj in culling:
+        obj.use_f3d_culling = False
     if culling:
-        listed = "\n  ".join(culling)
-        raise PluginError(f"Turn off Use F3D Culling on these, BK culls off its own center and radius:\n  {listed}")
+        counted = "1 object" if len(culling) == 1 else f"{len(culling)} objects"
+        settings.warnings.append(f"Turned Use F3D Culling off on {counted}. BK culls off its own center and radius.")
 
     # WriteAll emits a blanket othermode-H and leaks it, differing-and-revert
     # writes only what the world defaults don't cover

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -555,9 +555,9 @@ class BK64_ImportLevel(Operator):
                 if choice != "BOTH":
                     wanted = [half for half in wanted if half == choice]
                 if not wanted:
-                    raise PluginError(f"{level} has no {choice} half. It is opaque only.")
+                    raise PluginError(f"{level} is opaque only. Set Halves to Opaque or Both.")
 
-                triangles, brought = 0, []
+                triangles, brought, caveats = 0, [], []
                 for half in wanted:
                     path = _level_resource(folder, layers[half], level, half)
                     if path is None:
@@ -565,11 +565,28 @@ class BK64_ImportLevel(Operator):
                             f"{level} {half} isn't in that folder. It should hold "
                             f"ASSET_{layers[half]:04X}_{level}_{half} and its _GEO, _VTX and _tex siblings."
                         )
-                    _armature_obj, mesh_obj, _model = import_bk64_model(context, path, BK64_Settings(scene))
+                    _armature_obj, mesh_obj, model = import_bk64_model(context, path, BK64_Settings(scene))
+                    # so Export Level Halves puts it back where it came from
+                    mesh_obj.hm64_bk64_level_half = "TRANSLUCENT" if half == "XLU" else "OPAQUE"
                     triangles += len(mesh_obj.data.polygons)
                     brought.append(half)
+                    # the same things the model importer says, or a level round trips quietly wrong
+                    if model["dropped"]:
+                        caveats.append(f"{half}: {model['dropped']} triangles came in without their vertices.")
+                    if model["unbound_textures"]:
+                        caveats.append(
+                            f"{half}: {model['unbound_textures']} textures aren't bound by the display "
+                            "list and won't be there on the way out."
+                        )
+                    if model["mesh_list_dropped"]:
+                        caveats.append(
+                            f"{half}: {model['mesh_list_dropped']} mesh list vertices aren't drawn by the "
+                            "display list and won't be there on the way out."
+                        )
 
                 note = " Each half is its own object." if len(brought) > 1 else ""
+                for caveat in caveats:
+                    self.report({"WARNING"}, caveat)
                 self.report({"INFO"}, f"Imported {level} {' and '.join(brought)}, {triangles} triangles.{note}")
             return {"FINISHED"}
 
@@ -595,6 +612,8 @@ class BK64_ImportModel(Operator):
                 _armature_obj, mesh_obj, model = import_bk64_model(context, path, BK64_Settings(scene))
                 if model["bones"]:
                     scene.hm64_bk64_anim_scale = model["anim_scale"]
+                    # no bound model draws under a BONE command, so the table decides it
+                    scene.hm64_bk64_rigging = "BIND" if model["bound_vertices"] else "SPLIT"
                 scene.hm64_bk64_env_map = bool(model["geo_type"] & GEO_TYPE_ENV_MAP)
                 scene.hm64_bk64_mipmap = bool(model["geo_type"] & GEO_TYPE_MIPMAP_TRILINEAR)
 
@@ -604,10 +623,10 @@ class BK64_ImportModel(Operator):
                     notes.append(f"Its geo layout uses {', '.join(kept)}, kept for re-export.")
                 if model["mesh_list"]:
                     notes.append(f"Its mesh list came in as {len(model['mesh_list'])} vertex groups.")
-                    if not model["mesh_list_exact"]:
+                    if model["mesh_list_dropped"]:
                         notes.append(
-                            "Some of its meshes share a coordinate with geometry outside them, so a "
-                            "re-export puts more vertices in a mesh than vanilla did."
+                            f"{model['mesh_list_dropped']} of those vertices aren't drawn by the display "
+                            "list, so they won't come back on a re-export."
                         )
                 if model["shapes"]:
                     notes.append(f"{len(model['shape_objects'])} collision shapes are in their own collection.")
@@ -625,10 +644,10 @@ class BK64_ImportModel(Operator):
                     faces = len(model["collision_only_object"].data.polygons)
                     notes.append(f"{faces} collision triangles sit on geometry nothing draws, in their own mesh.")
                 if model["bones"]:
-                    notes.append("Animation Scale came in with it.")
-                    if model["bound_vertices"]:
-                        notes.append("Its rigging is bound vertices, weighted from the binding table.")
-                    elif not mesh_obj.vertex_groups:
+                    bound = bool(model["bound_vertices"])
+                    scheme = "Bind Vertices" if bound else "Split At Bones"
+                    notes.append(f"Animation Scale came in with it, and Rigging is set to {scheme}.")
+                    if not bound and not mesh_obj.vertex_groups:
                         notes.append("Nothing was weighted, the layout draws under no bone. Weight the mesh yourself.")
                 else:
                     notes.append("Static model, no bone table.")

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -40,7 +40,7 @@ def object_mode(context):
                 bpy.ops.object.mode_set(mode=previous)
 
 
-def _resolve_root(context):
+def resolve_root(context):
     """The object to export, an armature if rigged and a mesh otherwise"""
     # walks up to the root like MK64 does, letting any part of a rig work
     selected = context.selected_objects
@@ -80,7 +80,7 @@ class BK64_ExportModel(Operator):
 
         try:
             with object_mode(context):
-                root_obj = _resolve_root(context)
+                root_obj = resolve_root(context)
                 settings = BK64_Settings(scene)
 
                 export_dir = bpy.path.abspath(scene.hm64_bk64_export_path)
@@ -128,7 +128,7 @@ class BK64_ExportAnimation(Operator):
 
         try:
             with object_mode(context):
-                root_obj = _resolve_root(context)
+                root_obj = resolve_root(context)
                 if root_obj.type != "ARMATURE":
                     raise PluginError("Select the armature the animation is on, only rigged models animate.")
                 settings = BK64_Settings(scene)
@@ -165,7 +165,7 @@ class BK64_ExportAllAnimations(Operator):
 
         try:
             with object_mode(context):
-                armature_obj = _resolve_root(context)
+                armature_obj = resolve_root(context)
                 if armature_obj.type != "ARMATURE":
                     raise PluginError("Select the armature the actions are on, only rigged models animate.")
                 settings = BK64_Settings(scene)
@@ -348,7 +348,7 @@ class BK64_ImportAnimation(Operator):
         scene = context.scene
         try:
             with object_mode(context):
-                armature_obj = _resolve_root(context)
+                armature_obj = resolve_root(context)
                 if armature_obj.type != "ARMATURE":
                     raise PluginError("Select the armature to put the animation on.")
 

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -10,16 +10,22 @@ from bpy.utils import register_class, unregister_class
 from ...utility import PluginError, raisePluginError
 from .bk64_anim import actions_for, export_bk64_animation, import_bk64_animation
 from .bk64_constants import (
+    CAMERA_AREA_KIND,
     COLLISION_ONLY_PROP,
     GEO_TYPE_ENV_MAP,
     GEO_TYPE_MIPMAP_TRILINEAR,
     MESH_GROUP_PREFIX,
+    MODEL_STASH_PROPS,
     SCROLL_UID_BASE,
+    SHAPE_KIND,
 )
 from .bk64_import import import_bk64_model
-from .bk64_level_models import bk64_level_layers
+from .bk64_level_models import bk64_level_half_paths, bk64_level_layers
 from .bk64_model import (
+    blank_half_object,
     export_bk64_model,
+    LEVEL_HALVES,
+    level_half_objects,
     promote_materials_to_2_cycle,
     read_collision_only,
     read_collision_shapes,
@@ -121,6 +127,119 @@ class BK64_ExportModel(Operator):
         except Exception as exc:
             raisePluginError(self, exc)
             return {"CANCELLED"}
+
+
+def _half_holder(context, name, objects, temp_objects):
+    """An empty standing in for one half's model, holding what the export reads off a root"""
+    holder = bpy.data.objects.new(name, None)
+    context.scene.collection.objects.link(holder)
+    temp_objects.append(holder)
+    for prop in MODEL_STASH_PROPS:
+        stashed = next((obj[prop] for obj in objects if prop in obj), None)
+        if stashed is not None:
+            holder[prop] = stashed
+    # a real property rather than a custom one, so MODEL_STASH_PROPS can't carry it
+    holder.hm64_bk64_geo_type_raw = next(
+        (obj.hm64_bk64_geo_type_raw for obj in objects if obj.hm64_bk64_geo_type_raw), 0
+    )
+    return holder
+
+
+class BK64_ExportLevelHalves(Operator):
+    bl_idname = "scene.hm64_bk64_export_level_halves"
+    bl_label = "Export Level Halves"
+    bl_description = (
+        "Write the selected level as its opaque and translucent models. A vanilla level's halves go "
+        "out under their own asset names, which differ from each other"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        scene = context.scene
+        temp_objects = []
+        try:
+            with object_mode(context):
+                root_obj = resolve_root(context)
+                if root_obj.type == "ARMATURE":
+                    raise PluginError("A level is a static model. Select the level geometry, not an armature.")
+
+                settings = BK64_Settings(scene)
+                export_dir = bpy.path.abspath(scene.hm64_bk64_export_path)
+                if not export_dir:
+                    raise PluginError("Set an export folder first.")
+                if not settings.name:
+                    raise PluginError("Set a resource path first, e.g. levels/mylevel.")
+
+                sources = (
+                    [root_obj]
+                    if root_obj.type == "MESH"
+                    else [child for child in root_obj.children_recursive if child.type == "MESH"]
+                )
+                hidden = [obj for obj in sources if obj.get(COLLISION_ONLY_PROP)]
+                hidden_of = {
+                    half: [obj for obj in hidden if obj.hm64_bk64_level_half == half] for half, _ in LEVEL_HALVES
+                }
+                sources = [obj for obj in sources if not obj.ignore_render and not obj.get(COLLISION_ONLY_PROP)]
+                if not sources:
+                    raise PluginError(f"Nothing to export, '{root_obj.name}' has no mesh geometry.")
+
+                base_name, written, blanked = settings.name, [], []
+                extension = ".bin" if settings.file_format == "BIN" else ""
+                paths = bk64_level_half_paths(base_name)
+
+                for half, suffix in LEVEL_HALVES:
+                    layer = suffix.lstrip("_")
+                    halves = level_half_objects(sources, half)
+                    if not halves:
+                        halves = [blank_half_object(context, sources, half, temp_objects)]
+                        blanked.append(layer)
+
+                    holder = _half_holder(context, f"bk64_half_{half.lower()}", halves + hidden_of[half], temp_objects)
+
+                    def stand_in_for(obj, parent):
+                        # a copy shares the mesh data, so parenting one under the
+                        # holder leaves the user's own objects where they were
+                        copy = obj.copy()
+                        context.scene.collection.objects.link(copy)
+                        temp_objects.append(copy)
+                        copy.parent = parent
+                        copy.matrix_world = obj.matrix_world
+                        return copy
+
+                    for obj in halves + hidden_of[half]:
+                        stand_in = stand_in_for(obj, holder)
+                        # the collision volumes and camera gates hang off the model, not the
+                        # holder the export is handed, and both readers only walk children
+                        for child in obj.children_recursive:
+                            if child.get(SHAPE_KIND) is not None or child.get(CAMERA_AREA_KIND) is not None:
+                                stand_in_for(child, stand_in)
+
+                    settings.name = paths[layer]
+                    shapes = read_collision_shapes(holder, settings.scale)
+                    collision_only = read_collision_only(context, holder, settings.scale)
+                    resources = export_bk64_model(context, holder, settings, shapes, collision_only)
+                    for res_suffix, data in resources.items():
+                        path = os.path.join(export_dir, settings.name + res_suffix + extension)
+                        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+                        with open(path, "wb") as file:
+                            file.write(data)
+                    written.append(settings.name)
+
+                settings.name = base_name
+                for warning in settings.warnings:
+                    self.report({"WARNING"}, warning)
+                note = f" {' and '.join(blanked)} had no geometry and went out blank." if blanked else ""
+                self.report({"INFO"}, f"Exported {' and '.join(written)} to {export_dir}.{note}")
+            return {"FINISHED"}
+
+        except Exception as exc:
+            raisePluginError(self, exc)
+            return {"CANCELLED"}
+
+        finally:
+            for obj in temp_objects:
+                if obj.name in bpy.data.objects:
+                    bpy.data.objects.remove(obj, do_unlink=True)
 
 
 class BK64_ExportAnimation(Operator):
@@ -568,6 +687,7 @@ class BK64_ImportSkeleton(Operator):
 
 bk64_operator_classes = (
     BK64_ExportModel,
+    BK64_ExportLevelHalves,
     BK64_ExportAnimation,
     BK64_ExportAllAnimations,
     BK64_PromoteMaterials,

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -342,7 +342,10 @@ class BK64_ExportAllAnimations(Operator):
 class BK64_PromoteMaterials(Operator):
     bl_idname = "object.hm64_bk64_promote_materials"
     bl_label = "Promote Materials To 2 Cycle"
-    bl_description = "Give every material on the selected meshes a second cycle. BK renders a 1 cycle material black"
+    bl_description = (
+        "Give every material on the selected meshes the second cycle BK needs. Materials made in BK64 "
+        "mode already have it, so this is for a mesh brought in from elsewhere"
+    )
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -9,7 +9,13 @@ from bpy.utils import register_class, unregister_class
 
 from ...utility import PluginError, raisePluginError
 from .bk64_anim import actions_for, export_bk64_animation, import_bk64_animation
-from .bk64_constants import COLLISION_ONLY_PROP, GEO_TYPE_ENV_MAP, GEO_TYPE_MIPMAP_TRILINEAR
+from .bk64_constants import (
+    COLLISION_ONLY_PROP,
+    GEO_TYPE_ENV_MAP,
+    GEO_TYPE_MIPMAP_TRILINEAR,
+    MESH_GROUP_PREFIX,
+    SCROLL_UID_BASE,
+)
 from .bk64_import import import_bk64_model
 from .bk64_level_models import bk64_level_layers
 from .bk64_model import (
@@ -254,6 +260,42 @@ class BK64_SplitMeshAtBones(Operator):
                         else "Nothing to cut, every triangle already belongs to one bone."
                     ),
                 )
+            return {"FINISHED"}
+
+        except Exception as exc:
+            raisePluginError(self, exc)
+            return {"CANCELLED"}
+
+
+class BK64_AddTextureScroll(Operator):
+    bl_idname = "object.hm64_bk64_add_texture_scroll"
+    bl_label = "Add Texture Scroll"
+    bl_description = (
+        "Make the selected faces scroll their texture. Select them in edit mode first, and set the " "speed above"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        try:
+            mesh_obj = context.object
+            if mesh_obj is None or mesh_obj.type != "MESH":
+                raise PluginError("Select the mesh holding the faces to scroll.")
+
+            speed = context.scene.hm64_bk64_scroll_speed
+            # edit mode keeps the selection in a bmesh of its own, object mode is where it lands
+            with object_mode(context):
+                chosen = [vertex.index for vertex in mesh_obj.data.vertices if vertex.select]
+                if not chosen:
+                    raise PluginError("No vertices selected. Pick the faces to scroll in edit mode.")
+
+                name = f"{MESH_GROUP_PREFIX}{SCROLL_UID_BASE + speed}"
+                group = mesh_obj.vertex_groups.get(name) or mesh_obj.vertex_groups.new(name=name)
+                group.add(chosen, 1.0, "REPLACE")
+
+            self.report(
+                {"INFO"},
+                f"{len(chosen)} vertices scroll at {speed}, as '{name}'. The number in the name is the speed.",
+            )
             return {"FINISHED"}
 
         except Exception as exc:
@@ -530,6 +572,7 @@ bk64_operator_classes = (
     BK64_ExportAllAnimations,
     BK64_PromoteMaterials,
     BK64_SplitMeshAtBones,
+    BK64_AddTextureScroll,
     BK64_SelectLooseVertices,
     BK64_MarkCollisionOnly,
     BK64_ImportSkeleton,

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -27,7 +27,7 @@ from .bk64_model import (
     export_bk64_model,
     LEVEL_HALVES,
     level_half_objects,
-    level_half_of,
+    whole_level_half,
     promote_materials_to_2_cycle,
     read_collision_only,
     read_collision_shapes,
@@ -186,7 +186,8 @@ class BK64_ExportLevelHalves(Operator):
                     else [child for child in root_obj.children_recursive if child.type == "MESH"]
                 )
                 hidden = [obj for obj in sources if obj.get(COLLISION_ONLY_PROP)]
-                hidden_of = {half: [obj for obj in hidden if level_half_of(obj) == half] for half, _ in LEVEL_HALVES}
+                # a collision only mesh draws nothing, so no draw layer can place it
+                hidden_of = {half: [obj for obj in hidden if whole_level_half(obj) == half] for half, _ in LEVEL_HALVES}
                 sources = [obj for obj in sources if not obj.ignore_render and not obj.get(COLLISION_ONLY_PROP)]
                 if not sources:
                     raise PluginError(f"Nothing to export, '{root_obj.name}' has no mesh geometry.")
@@ -197,7 +198,7 @@ class BK64_ExportLevelHalves(Operator):
 
                 for half, suffix in LEVEL_HALVES:
                     layer = suffix.lstrip("_")
-                    halves = level_half_objects(sources, half)
+                    halves = level_half_objects(context, sources, half, temp_objects)
                     if not halves:
                         halves = [blank_half_object(context, sources, half, temp_objects)]
                         blanked.append(layer)

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -22,6 +22,7 @@ from .bk64_constants import (
 from .bk64_import import import_bk64_model
 from .bk64_level_models import bk64_level_half_paths, bk64_level_layers
 from .bk64_model import (
+    armature_of,
     blank_half_object,
     export_bk64_model,
     LEVEL_HALVES,
@@ -59,11 +60,19 @@ def resolve_root(context):
     if not selected:
         raise PluginError("Nothing selected. Pick the armature, or the mesh for a static model.")
 
-    for obj in selected:
+    for obj in selected:  # an explicit pick wins
         if obj.type == "ARMATURE":
             return obj
+
+    # the same rule the tools use, so what they split is what this exports
     for obj in selected:
-        current = obj
+        if obj.type == "MESH":
+            rig = armature_of(obj)
+            if rig is not None:
+                return rig
+
+    for obj in selected:
+        current = obj.parent
         while current is not None:
             if current.type == "ARMATURE":
                 return current

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -27,6 +27,7 @@ from .bk64_model import (
     export_bk64_model,
     LEVEL_HALVES,
     level_half_objects,
+    level_half_of,
     promote_materials_to_2_cycle,
     read_collision_only,
     read_collision_shapes,
@@ -185,9 +186,7 @@ class BK64_ExportLevelHalves(Operator):
                     else [child for child in root_obj.children_recursive if child.type == "MESH"]
                 )
                 hidden = [obj for obj in sources if obj.get(COLLISION_ONLY_PROP)]
-                hidden_of = {
-                    half: [obj for obj in hidden if obj.hm64_bk64_level_half == half] for half, _ in LEVEL_HALVES
-                }
+                hidden_of = {half: [obj for obj in hidden if level_half_of(obj) == half] for half, _ in LEVEL_HALVES}
                 sources = [obj for obj in sources if not obj.ignore_render and not obj.get(COLLISION_ONLY_PROP)]
                 if not sources:
                     raise PluginError(f"Nothing to export, '{root_obj.name}' has no mesh geometry.")
@@ -237,6 +236,12 @@ class BK64_ExportLevelHalves(Operator):
                 settings.name = base_name
                 for warning in settings.warnings:
                     self.report({"WARNING"}, warning)
+                for layer in blanked:
+                    self.report(
+                        {"WARNING"},
+                        f"Give a material Translucent, or set Level Half on the objects that belong in "
+                        f"the {layer} half.",
+                    )
                 note = f" {' and '.join(blanked)} had no geometry and went out blank." if blanked else ""
                 self.report({"INFO"}, f"Exported {' and '.join(written)} to {export_dir}.{note}")
             return {"FINISHED"}

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -234,7 +234,8 @@ class BK64_ExportLevelHalves(Operator):
                     written.append(settings.name)
 
                 settings.name = base_name
-                for warning in settings.warnings:
+                # both halves raise the same ones, and one settings collects them all
+                for warning in dict.fromkeys(settings.warnings):
                     self.report({"WARNING"}, warning)
                 for layer in blanked:
                     self.report(

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -20,7 +20,7 @@ from .bk64_constants import (
     SHAPE_KIND,
 )
 from .bk64_import import import_bk64_model
-from .bk64_level_models import bk64_level_half_paths, bk64_level_layers
+from .bk64_level_models import bk64_level_half_paths, bk64_level_layers, bk64_level_of_asset
 from .bk64_model import (
     armature_of,
     blank_half_object,
@@ -636,7 +636,18 @@ class BK64_ImportModel(Operator):
                 scene.hm64_bk64_env_map = bool(model["geo_type"] & GEO_TYPE_ENV_MAP)
                 scene.hm64_bk64_mipmap = bool(model["geo_type"] & GEO_TYPE_MIPMAP_TRILINEAR)
 
+                # a level is two models and this reads one, so say which it was
+                level = bk64_level_of_asset(path)
+                if level is not None:
+                    level_name, layer = level
+                    mesh_obj.hm64_bk64_level_half = "TRANSLUCENT" if layer == "XLU" else "OPAQUE"
+
                 notes = []
+                if level is not None:
+                    notes.append(
+                        f"It is the {layer} half of {level_name}, and Level Half is set to match. "
+                        "Import BK Level brings in both at once if you want them together."
+                    )
                 kept = model.get("geo_commands", ())
                 if kept:
                     notes.append(f"Its geo layout uses {', '.join(kept)}, kept for re-export.")

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -7,6 +7,7 @@ from ...panels import BK64_Panel
 from ...utility import prop_split
 from .bk64_constants import BK_COLLISION_FLAG_BITS
 from .bk64_operators import (
+    BK64_AddTextureScroll,
     BK64_ExportAllAnimations,
     BK64_ImportAnimation,
     BK64_ExportAnimation,
@@ -57,16 +58,11 @@ class BK64_ExportModelPanel(BK64_Panel):
             box.label(text="This model came in with its own geo type, so the two")
             box.label(text="boxes above do nothing. Set it to 0 to use them instead.")
 
-        col.operator(BK64_PromoteMaterials.bl_idname)
-        col.operator(BK64_SplitMeshAtBones.bl_idname)
-        col.operator(BK64_SelectLooseVertices.bl_idname)
-        col.operator(BK64_MarkCollisionOnly.bl_idname)
         col.operator(BK64_ExportModel.bl_idname)
 
         box = col.box().column()
         box.label(text="Select the armature, or the mesh for a static model.")
         box.label(text="Split At Bones needs the mesh cut first, Bind Vertices doesn't.")
-        box.label(text="Collision Only makes a mesh an invisible floor or wall.")
         box.label(text="Pack the folder with: torch pack <folder> <name>.o2r o2r")
 
 
@@ -126,6 +122,31 @@ class BK64_ImportModelPanel(BK64_Panel):
         box.label(text="hunt for its ASSET_ file. Unpack bk.o2r and point at the")
         box.label(text="assets/level folder inside. Each half comes in as its own")
         box.label(text="object, so the translucent one can be hidden while you work.")
+
+
+class BK64_MeshToolsPanel(BK64_Panel):
+    bl_idname = "BK64_PT_mesh_tools"
+    bl_label = "Mesh Tools"
+    bl_order = 3
+
+    def draw(self, context):
+        col = self.layout.column()
+        scene = context.scene
+
+        col.operator(BK64_PromoteMaterials.bl_idname)
+        col.operator(BK64_SplitMeshAtBones.bl_idname)
+        col.operator(BK64_SelectLooseVertices.bl_idname)
+        col.operator(BK64_MarkCollisionOnly.bl_idname)
+
+        col.separator()
+        prop_split(col, scene, "hm64_bk64_scroll_speed", "Scroll Speed")
+        col.operator(BK64_AddTextureScroll.bl_idname)
+
+        box = col.box().column()
+        box.label(text="These change the mesh you have selected, not the export.")
+        box.label(text="Collision Only makes a mesh an invisible floor or wall.")
+        box.label(text="Pick the faces in edit mode before Add Texture Scroll.")
+        box.label(text="Only the vertical direction moves, and only on a level.")
 
 
 class BK64_BonePanel(BK64_Panel):
@@ -204,6 +225,7 @@ bk64_panel_classes = (
     BK64_ExportModelPanel,
     BK64_ExportAnimationPanel,
     BK64_ImportModelPanel,
+    BK64_MeshToolsPanel,
     BK64_BonePanel,
     BK64_MaterialPanel,
 )

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -62,13 +62,21 @@ class BK64_ExportModelPanel(BK64_Panel):
 
         col.operator(BK64_ExportModel.bl_idname)
 
+        # its own box, or the settings above it read as its settings
         col.separator()
+        halves = col.box().column()
         obj = context.object
         if obj is not None and obj.type == "MESH":
-            prop_split(col, obj, "hm64_bk64_level_half", "Level Half")
+            prop_split(halves, obj, "hm64_bk64_level_half", "Level Half")
             if obj.hm64_bk64_level_half == "AUTO":
-                col.label(text=f"Its materials read as {level_half_of(obj).lower()}.")
-        col.operator(BK64_ExportLevelHalves.bl_idname)
+                halves.label(text=f"Its materials read as {level_half_of(obj).lower()}.")
+        # the root is usually not a mesh, so the row above is often missing
+        meshes = [] if root is None else ([root] if root.type == "MESH" else root.children_recursive)
+        drawn = [child for child in meshes if child.type == "MESH" and not child.ignore_render]
+        if len(drawn) > 1:  # one mesh already says what it reads as, just above
+            opaque = sum(1 for child in drawn if level_half_of(child) == "OPAQUE")
+            halves.label(text=f"{opaque} opaque, {len(drawn) - opaque} translucent")
+        halves.operator(BK64_ExportLevelHalves.bl_idname)
 
         box = col.box().column()
         box.label(text="Select the armature, or the mesh for a static model.")

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -137,6 +137,7 @@ class BK64_ImportModelPanel(BK64_Panel):
         box.label(text="Import BK Skeleton takes only the bones, ids included, so a")
         box.label(text="replacement accepts the original's animations.")
         box.label(text="Both need the _GEO, _VTX and _tex siblings in the same folder.")
+        box.label(text="For a level use Import BK Level below, a level is two models.")
 
         col.separator()
         prop_split(col, scene, "hm64_bk64_level_folder", "Level Folder")

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -6,6 +6,7 @@ from ...f3d.flipbook import drawTextureArray
 from ...panels import BK64_Panel
 from ...utility import prop_split
 from .bk64_constants import BK_COLLISION_FLAG_BITS
+from .bk64_model import level_half_of
 from .bk64_operators import (
     BK64_AddTextureScroll,
     BK64_ExportAllAnimations,
@@ -65,6 +66,8 @@ class BK64_ExportModelPanel(BK64_Panel):
         obj = context.object
         if obj is not None and obj.type == "MESH":
             prop_split(col, obj, "hm64_bk64_level_half", "Level Half")
+            if obj.hm64_bk64_level_half == "AUTO":
+                col.label(text=f"Its materials read as {level_half_of(obj).lower()}.")
         col.operator(BK64_ExportLevelHalves.bl_idname)
 
         box = col.box().column()

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -39,7 +39,7 @@ class BK64_ExportModelPanel(BK64_Panel):
         prop_split(col, scene, "hm64_bk64_scale", "Blender To BK Scale")
         prop_split(col, scene, "hm64_bk64_anim_scale", "Animation Scale")
         prop_split(col, scene, "hm64_bk64_rigging", "Rigging")
-        prop_split(col, scene, "hm64_bk64_draw_layer", "Draw Layer")
+        prop_split(col, scene, "hm64_bk64_draw_layer", "Default Draw Layer")
 
         col.prop(scene, "hm64_bk64_force_unlit")
 
@@ -76,7 +76,7 @@ class BK64_ExportModelPanel(BK64_Panel):
 
 class BK64_ExportAnimationPanel(BK64_Panel):
     bl_idname = "BK64_PT_export_animation"
-    bl_label = "Animation Exporter"
+    bl_label = "Animations"
     bl_order = 1
 
     def draw(self, context):

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -12,6 +12,7 @@ from .bk64_operators import (
     BK64_ImportAnimation,
     BK64_ExportAnimation,
     BK64_ExportModel,
+    BK64_ExportLevelHalves,
     BK64_ImportLevel,
     BK64_ImportModel,
     BK64_ImportSkeleton,
@@ -60,9 +61,16 @@ class BK64_ExportModelPanel(BK64_Panel):
 
         col.operator(BK64_ExportModel.bl_idname)
 
+        col.separator()
+        obj = context.object
+        if obj is not None and obj.type == "MESH":
+            prop_split(col, obj, "hm64_bk64_level_half", "Level Half")
+        col.operator(BK64_ExportLevelHalves.bl_idname)
+
         box = col.box().column()
         box.label(text="Select the armature, or the mesh for a static model.")
         box.label(text="Split At Bones needs the mesh cut first, Bind Vertices doesn't.")
+        box.label(text="Level Half picks which model, Export Level Halves writes both.")
         box.label(text="Pack the folder with: torch pack <folder> <name>.o2r o2r")
 
 

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -6,7 +6,7 @@ from ...f3d.flipbook import drawTextureArray
 from ...panels import BK64_Panel
 from ...utility import prop_split
 from .bk64_constants import BK_COLLISION_FLAG_BITS
-from .bk64_model import level_half_of
+from .bk64_model import in_level_half, level_half_faces
 from .bk64_operators import (
     BK64_AddTextureScroll,
     BK64_ExportAllAnimations,
@@ -69,13 +69,21 @@ class BK64_ExportModelPanel(BK64_Panel):
         if obj is not None and obj.type == "MESH":
             prop_split(halves, obj, "hm64_bk64_level_half", "Level Half")
             if obj.hm64_bk64_level_half == "AUTO":
-                halves.label(text=f"Its materials read as {level_half_of(obj).lower()}.")
+                if level_half_faces(obj, "OPAQUE") and level_half_faces(obj, "TRANSLUCENT"):
+                    halves.label(text="Its materials read as both, so it goes out cut in two.")
+                else:
+                    which = "translucent" if in_level_half(obj, "TRANSLUCENT") else "opaque"
+                    halves.label(text=f"Its materials read as {which}.")
         # the root is usually not a mesh, so the row above is often missing
         meshes = [] if root is None else ([root] if root.type == "MESH" else root.children_recursive)
         drawn = [child for child in meshes if child.type == "MESH" and not child.ignore_render]
         if len(drawn) > 1:  # one mesh already says what it reads as, just above
-            opaque = sum(1 for child in drawn if level_half_of(child) == "OPAQUE")
-            halves.label(text=f"{opaque} opaque, {len(drawn) - opaque} translucent")
+            counts = {"OPAQUE": 0, "TRANSLUCENT": 0}
+            for child in drawn:
+                for half in counts:
+                    if in_level_half(child, half):
+                        counts[half] += 1
+            halves.label(text=f"{counts['OPAQUE']} opaque, {counts['TRANSLUCENT']} translucent")
         halves.operator(BK64_ExportLevelHalves.bl_idname)
 
         box = col.box().column()

--- a/fast64_internal/hm64/bk64/bk64_panels.py
+++ b/fast64_internal/hm64/bk64/bk64_panels.py
@@ -18,6 +18,7 @@ from .bk64_operators import (
     BK64_MarkCollisionOnly,
     BK64_SelectLooseVertices,
     BK64_SplitMeshAtBones,
+    resolve_root,
 )
 
 
@@ -39,8 +40,22 @@ class BK64_ExportModelPanel(BK64_Panel):
         prop_split(col, scene, "hm64_bk64_draw_layer", "Draw Layer")
 
         col.prop(scene, "hm64_bk64_force_unlit")
-        col.prop(scene, "hm64_bk64_env_map")
-        col.prop(scene, "hm64_bk64_mipmap")
+
+        # an imported model writes its own geo type, and these two lose to it
+        try:
+            root = resolve_root(context)
+        except Exception:  # a draw callback must never raise
+            root = None
+        stored = root.hm64_bk64_geo_type_raw if root is not None else 0
+        sub = col.column()
+        sub.enabled = not stored
+        sub.prop(scene, "hm64_bk64_env_map")
+        sub.prop(scene, "hm64_bk64_mipmap")
+        if stored:
+            prop_split(col, root, "hm64_bk64_geo_type_raw", "Imported Geo Type")
+            box = col.box().column()
+            box.label(text="This model came in with its own geo type, so the two")
+            box.label(text="boxes above do nothing. Set it to 0 to use them instead.")
 
         col.operator(BK64_PromoteMaterials.bl_idname)
         col.operator(BK64_SplitMeshAtBones.bl_idname)

--- a/fast64_internal/hm64/bk64/bk64_presets.py
+++ b/fast64_internal/hm64/bk64/bk64_presets.py
@@ -455,6 +455,11 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_XLU_SURF2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
+# BK reads its own draw layer
+_scene_layer = bpy.context.scene.hm64_bk64_draw_layer
+bpy.context.material.hm64_bk64_draw_layer = (
+    'TRANSLUCENT_NO_AA' if _scene_layer.endswith('_NO_AA') else 'TRANSLUCENT'
+)
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Shaded Texture Transparent'
@@ -794,6 +799,11 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_XLU_SURF2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
+# BK reads its own draw layer
+_scene_layer = bpy.context.scene.hm64_bk64_draw_layer
+bpy.context.material.hm64_bk64_draw_layer = (
+    'TRANSLUCENT_NO_AA' if _scene_layer.endswith('_NO_AA') else 'TRANSLUCENT'
+)
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Vertex Colored Texture Transparent'

--- a/fast64_internal/hm64/bk64/bk64_properties.py
+++ b/fast64_internal/hm64/bk64/bk64_properties.py
@@ -94,7 +94,7 @@ bk64_draw_layer_enum = (
 )
 
 bk64_material_draw_layer_enum = (
-    ("SCENE", "From Scene", "Whatever the export panel's Draw Layer says"),
+    ("SCENE", "From Scene", "Whatever the export panel's Default Draw Layer says"),
     ("INHERIT", "Inherit", "Sets no render mode and draws with whatever the chunk before it left"),
 ) + bk64_draw_layer_enum
 
@@ -250,11 +250,11 @@ def bk64_properties_register():
         "Vertices keeps it whole and weights each vertex to one bone",
     )
     bpy.types.Scene.hm64_bk64_draw_layer = EnumProperty(
-        name="Draw Layer",
+        name="Default Draw Layer",
         items=bk64_draw_layer_enum,
         default="OPAQUE",
-        description="Opaque for solid geometry, Translucent for blended. Whether the model reads "
-        "or writes depth stays with the game",
+        description="The layer a material takes when its own Draw Layer is From Scene. It does not "
+        "split a level into halves--Level Half does that",
     )
     bpy.types.Scene.hm64_bk64_scroll_speed = IntProperty(
         name="Scroll Speed",

--- a/fast64_internal/hm64/bk64/bk64_properties.py
+++ b/fast64_internal/hm64/bk64/bk64_properties.py
@@ -81,6 +81,11 @@ bk64_file_format_enum = (
     ("BIN", "BK Model Binary", "One .bin in the game's own format, for the ROM hacking tools"),
 )
 
+bk64_level_half_enum = (
+    ("OPAQUE", "Opaque", "Writes depth, so it hides what is behind it"),
+    ("TRANSLUCENT", "Translucent", "Tests depth without writing it. Vanilla puts water here"),
+)
+
 bk64_draw_layer_enum = (
     ("OPAQUE", "Opaque", "Solid geometry"),
     ("OPAQUE_NO_AA", "Opaque, No AA", "Solid, without the antialiased edge"),
@@ -155,7 +160,7 @@ _BK64_SCENE_PROPS = (
     "hm64_bk64_scroll_speed",
 )
 
-_BK64_OBJECT_PROPS = ("hm64_bk64_geo_type_raw",)
+_BK64_OBJECT_PROPS = ("hm64_bk64_level_half", "hm64_bk64_geo_type_raw")
 
 _BK64_BONE_PROPS = (
     "hm64_bk64_bone_id",
@@ -265,6 +270,13 @@ def bk64_properties_register():
         min=0,
         description="The geo type word an imported model came in with, written back as it is. It sits "
         "on the object because a level's two halves differ. Set it to 0 to use Env Map and Mipmap",
+    )
+    bpy.types.Object.hm64_bk64_level_half = EnumProperty(
+        name="Level Half",
+        items=bk64_level_half_enum,
+        default="OPAQUE",
+        description="Which of a level's two models Export Level Halves writes this object into. The "
+        "level importer sets it on the halves it brings in",
     )
     bpy.types.Scene.hm64_bk64_import_path = StringProperty(
         name="Model File",

--- a/fast64_internal/hm64/bk64/bk64_properties.py
+++ b/fast64_internal/hm64/bk64/bk64_properties.py
@@ -10,6 +10,7 @@ from .bk64_constants import (
     GEO_TYPE_ENV_MAP,
     GEO_TYPE_MIPMAP_TRILINEAR,
     MAX_BONE_ID,
+    MAX_SCROLL_SPEED,
     RENDERMODE_AA_OPAQUE,
 )
 from .bk64_level_models import bk64_level_layers, bk64_level_names
@@ -151,6 +152,7 @@ _BK64_SCENE_PROPS = (
     "hm64_bk64_anim_path",
     "hm64_bk64_anim_include_rest",
     "hm64_bk64_anim_import_path",
+    "hm64_bk64_scroll_speed",
 )
 
 _BK64_OBJECT_PROPS = ("hm64_bk64_geo_type_raw",)
@@ -248,6 +250,14 @@ def bk64_properties_register():
         default="OPAQUE",
         description="Opaque for solid geometry, Translucent for blended. Whether the model reads "
         "or writes depth stays with the game",
+    )
+    bpy.types.Scene.hm64_bk64_scroll_speed = IntProperty(
+        name="Scroll Speed",
+        min=1,
+        max=MAX_SCROLL_SPEED,
+        default=20,
+        description="How fast Add Texture Scroll slides the selected faces. In Banjo's Backpack, "
+        "Slow, Normal and Fast are 6, 20 and 60",
     )
     bpy.types.Object.hm64_bk64_geo_type_raw = IntProperty(
         name="Imported Geo Type",

--- a/fast64_internal/hm64/bk64/bk64_properties.py
+++ b/fast64_internal/hm64/bk64/bk64_properties.py
@@ -82,6 +82,7 @@ bk64_file_format_enum = (
 )
 
 bk64_level_half_enum = (
+    ("AUTO", "From Materials", "Translucent when every material on it is, opaque otherwise"),
     ("OPAQUE", "Opaque", "Writes depth, so it hides what is behind it"),
     ("TRANSLUCENT", "Translucent", "Tests depth without writing it. Vanilla puts water here"),
 )
@@ -274,9 +275,10 @@ def bk64_properties_register():
     bpy.types.Object.hm64_bk64_level_half = EnumProperty(
         name="Level Half",
         items=bk64_level_half_enum,
-        default="OPAQUE",
-        description="Which of a level's two models Export Level Halves writes this object into. The "
-        "level importer sets it on the halves it brings in",
+        default="AUTO",
+        description="Which of a level's two models Export Level Halves writes this object into. From "
+        "Materials reads it off the materials. The level importer sets it on the halves it brings in. "
+        "It has nothing to do with Default Draw Layer",
     )
     bpy.types.Scene.hm64_bk64_import_path = StringProperty(
         name="Model File",

--- a/fast64_internal/hm64/bk64/bk64_properties.py
+++ b/fast64_internal/hm64/bk64/bk64_properties.py
@@ -153,6 +153,8 @@ _BK64_SCENE_PROPS = (
     "hm64_bk64_anim_import_path",
 )
 
+_BK64_OBJECT_PROPS = ("hm64_bk64_geo_type_raw",)
+
 _BK64_BONE_PROPS = (
     "hm64_bk64_bone_id",
     "hm64_bk64_bone_order",
@@ -246,6 +248,13 @@ def bk64_properties_register():
         default="OPAQUE",
         description="Opaque for solid geometry, Translucent for blended. Whether the model reads "
         "or writes depth stays with the game",
+    )
+    bpy.types.Object.hm64_bk64_geo_type_raw = IntProperty(
+        name="Imported Geo Type",
+        default=0,
+        min=0,
+        description="The geo type word an imported model came in with, written back as it is. It sits "
+        "on the object because a level's two halves differ. Set it to 0 to use Env Map and Mipmap",
     )
     bpy.types.Scene.hm64_bk64_import_path = StringProperty(
         name="Model File",
@@ -441,6 +450,9 @@ def bk64_properties_unregister():
     for prop in _BK64_SCENE_PROPS:
         if hasattr(bpy.types.Scene, prop):
             delattr(bpy.types.Scene, prop)
+    for prop in _BK64_OBJECT_PROPS:
+        if hasattr(bpy.types.Object, prop):
+            delattr(bpy.types.Object, prop)
     for prop in _BK64_BONE_PROPS:
         if hasattr(bpy.types.Bone, prop):
             delattr(bpy.types.Bone, prop)

--- a/fast64_internal/hm64/bk64/bk64_rom.py
+++ b/fast64_internal/hm64/bk64/bk64_rom.py
@@ -30,6 +30,19 @@ from .bk64_constants import (
 )
 
 
+def vertex_bounds(bounds, endian: str = "<"):
+    """The BKVertexList header, the same twelve fields in a resource and in a .bin"""
+    return struct.pack(
+        endian + "hhhhhhhhhhHh",
+        *(s16(value) for value in bounds["min"]),
+        *(s16(value) for value in bounds["max"]),
+        *(s16(value) for value in bounds["center"]),
+        s16(bounds["local_norm"]),
+        bounds["count"],
+        s16(bounds["global_norm"]),
+    )
+
+
 def vertex_records(vertices, endian: str = "<"):
     """N64 Vtx records, 16 bytes each. Little endian for a resource, big endian for a ROM"""
     data = bytearray()
@@ -437,17 +450,7 @@ def write_bkmodelbin(
 
     _pad8(out)
     offsets["vtx"] = len(out)
-    out.extend(
-        struct.pack(
-            ">hhhhhhhhhhHh",
-            *(s16(value) for value in bounds["min"]),
-            *(s16(value) for value in bounds["max"]),
-            *(s16(value) for value in bounds["center"]),
-            s16(bounds["local_norm"]),
-            bounds["count"],
-            s16(bounds["global_norm"]),
-        )
-    )
+    out.extend(vertex_bounds(bounds, ">"))
     out.extend(vertex_records(vertices, ">"))
 
     if shapes:

--- a/fast64_internal/hm64/bk64/bk64_rom.py
+++ b/fast64_internal/hm64/bk64/bk64_rom.py
@@ -263,6 +263,29 @@ def collision_shapes(shapes, endian: str = "<"):
     return bytes(data)
 
 
+def read_camera_area_list(data, offset: int, endian: str = "<", pad_header: bool = False):
+    """The boxes a geo CAMERA command tests the camera against"""
+    count = data[offset]
+    offset += 2 if pad_header else 1  # BKCameraAreaList pads after the count, the resource stream doesn't
+    areas = []
+    for _ in range(count):
+        box = struct.unpack_from(endian + "6h", data, offset)
+        areas.append(dict(min=list(box[:3]), max=list(box[3:])))
+        offset += 14  # 3+3 coordinates, then in_bounds and its pad
+    return areas
+
+
+def camera_area_list(areas, endian: str = "<", pad_header: bool = False):
+    """A count, then each box. in_bounds is run time state and ships as 0"""
+    data = bytearray(struct.pack(endian + "B", len(areas)))
+    if pad_header:
+        data.extend(bytes(1))
+    for area in areas:
+        data.extend(struct.pack(endian + "6h", *(s16(v) for v in area["min"]), *(s16(v) for v in area["max"])))
+        data.extend(bytes(2))
+    return bytes(data)
+
+
 def mesh_list(meshes, endian: str = "<"):
     """A count, then each mesh's uid and the vertices it holds"""
     data = bytearray(struct.pack(endian + "h", len(meshes)))
@@ -383,6 +406,7 @@ def write_bkmodelbin(
     vertices,
     collision,
     shapes,
+    camera_areas,
     bound_vertices,
     meshes,
     animated_slots,
@@ -451,6 +475,11 @@ def write_bkmodelbin(
         offsets["anim_vertices"] = len(out)
         out.extend(vertex_bone_map(bound_vertices, ">", pad_header=True))
 
+    if camera_areas:
+        _pad8(out)
+        offsets["camera"] = len(out)
+        out.extend(camera_area_list(camera_areas, ">", pad_header=True))
+
     if meshes:
         _pad8(out)
         offsets["mesh_list"] = len(out)
@@ -482,7 +511,7 @@ def write_bkmodelbin(
         offsets.get("unk14", 0),
         offsets.get("anim", 0),
         offsets.get("collision", 0),
-        0,  # camera areas
+        offsets.get("camera", 0),
         offsets.get("mesh_list", 0),
         offsets.get("anim_vertices", 0),
         offsets.get("animated_texture", 0),

--- a/fast64_internal/hm64/bk64/bk64_texture.py
+++ b/fast64_internal/hm64/bk64/bk64_texture.py
@@ -147,14 +147,15 @@ def collect_textures(
         otex_format = F3D_FMT_TO_OTEX.get((fImage.fmt, fImage.bitSize))
         if otex_format is None:
             raise PluginError(
-                f"Texture '{fImage.name}' uses {fImage.fmt}/{fImage.bitSize}, which has no BK equivalent."
+                f"Texture '{fImage.name}' uses {fImage.fmt}/{fImage.bitSize}, which has no BK "
+                "equivalent. Use RGBA16, RGBA32, CI4, CI8, I4, I8, IA4, IA8 or IA16."
             )
         if isinstance(key, FPaletteKey):
             continue
         if embed_images and otex_format not in BIN_TEX_FORMATS:
             raise PluginError(
-                f"Texture '{fImage.name}' is {otex_format}, which BKTextureInfo has no type bit "
-                "for. Use RGBA16, RGBA32, IA8, CI4 or CI8."
+                f"Texture '{fImage.name}' is {otex_format}, which a .bin has no room to describe. "
+                "Use RGBA16, RGBA32, IA8, CI4 or CI8, or export o2r."
             )
         if embed_images and _hd_scale_of(fImage) is not None:
             raise PluginError(
@@ -396,6 +397,15 @@ def _flatten_shade(data: bytes, otex_format: str, fold, opaque: bool):
     return bytes(out)
 
 
+def _check_frame_size(frame, encoded, first):
+    """Refuses a frame that didn't encode to frame 0's size"""
+    if len(encoded) != len(first):
+        raise PluginError(
+            f"Frame '{frame.name}' encodes to {len(encoded)} bytes and frame 0 to {len(first)}. "
+            "Every frame has to be the same size and format."
+        )
+
+
 def _strip_pixels(fImage, frames, otex_format: str):
     """Every frame's N64 bytes end to end, frame 0 first"""
     from ...f3d.f3d_texture_writer import writeNonCITextureData
@@ -405,11 +415,7 @@ def _strip_pixels(fImage, frames, otex_format: str):
     for frame in frames[1:]:
         spare = FImage(frame.name, fImage.fmt, fImage.bitSize, frame.size[0], frame.size[1], None)
         writeNonCITextureData(frame, spare, otex_format)
-        if len(spare.data) != len(first):
-            raise PluginError(
-                f"Frame '{frame.name}' encodes to {len(spare.data)} bytes and frame 0 to {len(first)}. "
-                "Every frame has to be the same size and format."
-            )
+        _check_frame_size(frame, spare.data, first)
         encoded += spare.data
     return bytes(encoded)
 
@@ -430,11 +436,7 @@ def _strip_ci_pixels(fImage, frames, otex_format: str, palette0: bytes):
             )
         spare = FImage(frame.name, fImage.fmt, fImage.bitSize, frame.size[0], frame.size[1], None)
         writeCITextureData(frame, spare, colors, "RGBA16", otex_format)
-        if len(spare.data) != len(first):
-            raise PluginError(
-                f"Frame '{frame.name}' encodes to {len(spare.data)} bytes and frame 0 to {len(first)}. "
-                "Every frame has to be the same size and format."
-            )
+        _check_frame_size(frame, spare.data, first)
         palette = bytearray(pal_size)
         for index, color in enumerate(colors):
             palette[index * 2] = color >> 8


### PR DESCRIPTION
### Fixes
- Mesh list membership rides on the vertex now, instead of being matched back by coordinate.
- An imported model keeps the geo type it came in with.
- Camera gate boxes import and export.
- Camera subtrees get relinked when a stored geo layout is rewritten.
- Bone seams come from the stored layout as well as the weights.
- The transparent presets set BK's draw layer.
- An import sets Rigging and Level Half to what it read, and says what won't go back out.
- The export finds a rig off the selected mesh, like Split Mesh At Bones does.

### New
- **Export Level Halves** writes a level's `_OPA` and `_XLU` together, under vanilla's own asset names. Level Half is per object and reads From Materials by default, so an object whose materials are all Translucent goes to XLU and an existing file exports both halves with nothing set. Its controls sit in their own box with a count of what goes where.
- **Add Texture Scroll** puts the selected faces in the uid band the game reads a scroll speed from. It's in a new **Mesh Tools** panel, with the four mesh operators that were buried in the export panel.

### Cleanup
- Use F3D Culling turns itself off and warns instead of refusing to export.
- More errors rewritten to be user friendly.
- README restructured.

### Shared code
`Vtx` and `BufferVertex` take an optional `meshTag`, threaded through `TriangleConverterInfo`. Other games pass none, and a synthetic SM64 mesh hashes identically with and without it.
