### PR TITLE
Banjo-Tooie model imports, plus cull state and bone order fixes

### DIFF
--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -53,7 +53,7 @@ The vertex color's alpha channel only reaches the output if the alpha combiner t
 
 No preset sets a render mode, and none should. A chunk jumps into the render mode table the game builds instead, picked by its Draw Layer. Ticking Set Render Mode writes a mode into the display list after that jump, which overrides it and takes the actor's depth behavior away from the game.
 
-The viewport previews a material the way its render mode preset describes, so a cutout clips and a transparent one blends while you work. That preset is preview only. What the game actually renders with comes from Draw Layer, below. The transparent presets set that for you, so the two start out agreeing. Nothing holds them together afterwards: move a material to the opaque layer and it still previews blended while it ships solid.
+The viewport previews a material the way its render mode preset describes, so a cutout clips and a transparent one blends while you work. That preset is preview only. What the game actually renders with comes from Draw Layer, below. The cutout and transparent presets set that to Translucent for you, and the rest put it back to From Scene. A cutout gets no alpha on the opaque entry. Nothing holds them together afterwards: move a material to the opaque layer and it still previews blended while it ships solid.
 
 Force Unlit Shade, on by default, does that baking. It calculates what the RSP would have shaded each vertex, ambient plus every light facing it, from the material's light colors and directions and the vertex normal. The result goes to the vertex color. An unlit material already has a color there and passes it through untouched. A mesh painted by hand or baked in Blender exports as it looks.
 

--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -228,6 +228,8 @@ A rigged Tooie model imports welded at its joints, which the export refuses. Run
 
 Some models come in untextured, mostly levels. Their textures sit in a bank the whole game shares rather than in the model itself, and the import says which ones did that when it finishes. The materials still import, so the geometry is usable and the images are what's missing. You also get collision, but its fields are a guess. They're read with Kazooie's bit meanings, which nothing has confirmed Tooie shares, so check the collision type and sound on an imported material before you ship it. A word the fields can't describe comes in as Raw Flags and goes back out as it arrived.
 
+Two things in a Tooie layout crash the port: it gates parts of a model with appendages Kazooie's table doesn't hold, and it nests bones deeper than the matrix stack. The export corrects both and says what it changed. Read that note, since geometry Tooie gated will now always draw.
+
 ** Tooie support is experimental at best and should be considered a bonus to fast64's Kazooie support **
 
 ### Levels

--- a/fast64_internal/hm64/bk64/README.md
+++ b/fast64_internal/hm64/bk64/README.md
@@ -221,6 +221,15 @@ Imported materials come in unlit, apart from the reflective ones, because a BK m
 
 An imported animation is not a byte for byte copy of the original when exported again. It is exact on every whole frame, to within the translation step above. Between two frames it can differ by a couple of BK units. A key can only sit on a whole frame, and the original's curve leaves the line through its own per frame values by up to two degrees. Use this to read an animation to see how it moves, or to adjust it.
 
+### Banjo-Tooie Models
+"Import BK Model" reads Banjo-Tooie models too, detected from the file like any other. Models and their skeletons come in, animations don't. Tooie draws with a different microcode, and the import converts its display lists on the way in, so there's no extra effort for you to do. What comes in exports again as a Banjo-Kazooie model, in either format. That makes this a way to bring Tooie geometry, rigs and collision into a Kazooie hack, and it is the only thing the export does with one. Nothing writes Tooie's own format back.
+
+A rigged Tooie model imports welded at its joints, which the export refuses. Run Split Mesh At Bones on it, or set Rigging to Bind Vertices, and it writes either format. Bone IDs come in as Tooie numbered them, and no Kazooie animation addresses those, so a Tooie model dropped in as an actor holds its rest pose. Replacing A Vanilla Model, below, covers matching a stand-in's IDs to the actor it replaces.
+
+Some models come in untextured, mostly levels. Their textures sit in a bank the whole game shares rather than in the model itself, and the import says which ones did that when it finishes. The materials still import, so the geometry is usable and the images are what's missing. You also get collision, but its fields are a guess. They're read with Kazooie's bit meanings, which nothing has confirmed Tooie shares, so check the collision type and sound on an imported material before you ship it. A word the fields can't describe comes in as Raw Flags and goes back out as it arrived.
+
+** Tooie support is experimental at best and should be considered a bonus to fast64's Kazooie support **
+
 ### Levels
 A level's geometry is two models rather than one. The game loads an opaque half and a translucent half as separate resources, named for the level and which half they are: Treasure Trove Cove is `ASSET_146B_TTC_TREASURE_TROVE_COVE_OPA` and `ASSET_146C_TTC_TREASURE_TROVE_COVE_XLU`. Most maps have both halves, and some only the OPA.
 

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -149,6 +149,18 @@ OP_POPMTX = 0xBD
 G_LIGHTING = 0x00020000
 G_TEXTURE_GEN = 0x00040000
 
+G_SHADE = 0x00000004
+G_SHADING_SMOOTH = 0x00000200
+G_CULL_BOTH = 0x00003000
+G_FOG = 0x00010000
+G_TEXTURE_GEN_LINEAR = 0x00080000
+G_LOD = 0x00100000
+
+# every vanilla sublist opens with this clear.
+GEO_MODE_CHUNK_CLEAR = (
+    G_SHADE | G_SHADING_SMOOTH | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR | G_LOD
+)
+
 # geometry mode bit -> the rdp_settings flag that writes it again
 GEO_MODE_FLAGS = {
     0x00000001: "g_zbuffer",
@@ -369,7 +381,7 @@ bk64_world_defaults = {
     "geometryMode": {
         "zBuffer": True,
         "shade": True,
-        "cullBack": False,  # the per frame clear drops it and nothing puts it back
+        "cullBack": False,  # cleared per frame and again at every chunk head
         "lighting": False,  # the model path loads no lights
         "shadeSmooth": True,
         "clipping": False,  # nothing in the game ever sets it

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -2,6 +2,7 @@ import struct
 
 # Torch ResourceType fourccs, little endian
 RT_BK_MODEL = 0x424B4D4F
+RT_BT_MODEL = 0x42544D4F
 RT_BK_ANIM = 0x424B414E
 RT_VERTEX = 0x4F565458
 RT_BLOB = 0x4F424C42
@@ -91,6 +92,9 @@ GEO_CMD_TEXWRAP = 0x10  # 1 clamps the mipmap tiles that follow, 2 wraps them
 # Tooie's drawing commands and the sub-lists each one names, keyed by opcode
 # since nothing decoded tells the three apart
 GEO_CMD_BT_DRAW_SLOTS = {0x11: 1, 0x16: 8, 0x18: 6}
+BT_DRAW_COMMAND_WORDS = {0x11: 4, 0x16: 8, 0x18: 20}  # every u16 each one carries, not just the offsets
+BT_HITBOX_SIZES = (23, 15, 10)  # a resource's three hitbox lists, none of which BK draws
+BT_UNK20_SIZE = 13  # three coordinates, three more and a byte
 
 GEO_CMD_SIZE = 12  # every geo command is padded to 12 bytes
 GEO_BONE_BRANCH_OFFSET = 12  # BONE to its own LOADDL

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -67,6 +67,7 @@ TILE_BITS = {0: 4, 1: 8, 2: 16, 3: 32}  # G_SETTILE's siz, the depth the RDP dra
 # frame the game slides that segment's base on by frame_size bytes.
 SEG_ANIM_BASE = 15
 ANIM_TEX_SLOT_COUNT = 4
+BT_ANIM_TEX_SLOT_COUNT = 7  # Tooie's list is 56 bytes, segments 15 down to 9
 ANIM_FRAME_FORMATS = frozenset(("RGBA16", "RGBA32", "IA8", "CI4", "CI8"))  # a CI frame carries its palette with it
 
 MAX_TEXTURE_DIM = 255  # BKTextureInfo stores width/height as u8
@@ -86,6 +87,10 @@ GEO_CMD_DRAWDIST = 0x0D
 GEO_CMD_CULL = 0x0E  # a sphere the game tests before drawing what hangs off it
 GEO_CMD_CAMERA = 0x0F  # the areas what hangs off it draws inside, or outside with flag 2
 GEO_CMD_TEXWRAP = 0x10  # 1 clamps the mipmap tiles that follow, 2 wraps them
+
+# Tooie's drawing commands and the sub-lists each one names, keyed by opcode
+# since nothing decoded tells the three apart
+GEO_CMD_BT_DRAW_SLOTS = {0x11: 1, 0x16: 8, 0x18: 6}
 
 GEO_CMD_SIZE = 12  # every geo command is padded to 12 bytes
 GEO_BONE_BRANCH_OFFSET = 12  # BONE to its own LOADDL
@@ -124,6 +129,8 @@ MIP_PYRAMID_SIZE = (0x600 - MIP_TEXTURE_DIM * MIP_TEXTURE_DIM) * 2
 GEO_TYPE_ENV_MAP = 0x04
 
 # BK is F3DEX 1
+OP_MTX = 0x01
+G_MTX_PUSH = 0x04  # in OP_MTX's flags byte, where F3DEX2 puts it at 0x01
 OP_MOVEMEM = 0x03
 OP_MOVEWORD = 0xBC
 OP_DL = 0x06
@@ -181,6 +188,7 @@ GEO_MODE_START = 0x00000001 | 0x00000004 | 0x00000200  # zbuffer, shade, shade s
 # getLightDefinitions' default direction, as the signed bytes the RSP would get
 DEFAULT_LIGHT_DIR = (0x49, 0x49, 0x49)
 
+SEG_BT_BONE_MTX = 5  # Tooie's bone matrices, at the bone's table index times MTX_SIZE
 SEG_RENDERMODE = 3
 RENDERMODE_ENTRY_STRIDE = 16  # 2 Gfx, as a byte offset into the table
 RENDERMODE_OPAQUE = 0  # G_RM_OPA_SURF2

--- a/fast64_internal/hm64/bk64/bk64_constants.py
+++ b/fast64_internal/hm64/bk64/bk64_constants.py
@@ -105,6 +105,7 @@ GEO_DRAWDIST_SIZE = 24  # a s16 box and the branch, padded from 22
 GEO_SORT_SIZE = 40  # two f32 points, flags and two branches
 
 MAX_APPENDAGE_ID = 0x29  # the visibility table is 0x2A entries, and SELECTOR treats 0 as unset
+MAX_BONE_NESTING = 9  # the RSP's modelview stack holds ten, and no vanilla layout nests past this
 
 MAX_DRAWABLE_BONE_INDEX = 127  # geo_cmd_bone_s.anim_matrix_id is an s8
 MAX_BONE_ID = 0x6C  # the bone transform table is 0x6D entries, indexed by id unchecked

--- a/fast64_internal/hm64/bk64/bk64_geo.py
+++ b/fast64_internal/hm64/bk64/bk64_geo.py
@@ -8,8 +8,11 @@ from ...utility import PluginError
 from .bk64_constants import (
     ANIM_TEX_SLOT_COUNT,
     G_LIGHTING,
+    G_SHADE,
+    G_SHADING_SMOOTH,
     G_TEXTURE_GEN,
     GEO_LAYOUT_PROP,
+    GEO_MODE_CHUNK_CLEAR,
     MAX_APPENDAGE_ID,
     MIP_LOAD_BLOCK,
     MIP_LOAD_TILE,
@@ -358,7 +361,10 @@ def fixup_chunk(words, texture_count: int, rendermode_entry, white_offset=None, 
     # texture gen reads, and modelRender hands it a LookAt and no lights, the
     # same as vanilla.
     reflective = any(((w0 >> 24) & 0xFF) == OP_SETGEOMETRYMODE and (w1 & G_TEXTURE_GEN) for w0, w1 in words)
-    out = [] if reflective else [(OP_CLEARGEOMETRYMODE << 24, G_LIGHTING)]  # the model path loads no lights
+    out = [
+        (OP_CLEARGEOMETRYMODE << 24, GEO_MODE_CHUNK_CLEAR),
+        (OP_SETGEOMETRYMODE << 24, G_SHADE | G_SHADING_SMOOTH),  # the clear takes shade and no material puts it back
+    ]
     if rendermode_entry is not None:
         # jump into the table instead of setting a mode, leaving the actor's depth mode to hold
         out.append((OP_DL << 24, (SEG_RENDERMODE << 24) | (rendermode_entry * RENDERMODE_ENTRY_STRIDE)))

--- a/fast64_internal/hm64/bk64/bk64_geo.py
+++ b/fast64_internal/hm64/bk64/bk64_geo.py
@@ -14,6 +14,7 @@ from .bk64_constants import (
     GEO_LAYOUT_PROP,
     GEO_MODE_CHUNK_CLEAR,
     MAX_APPENDAGE_ID,
+    MAX_BONE_NESTING,
     MIP_LOAD_BLOCK,
     MIP_LOAD_TILE,
     NO_PARENT,
@@ -110,6 +111,73 @@ def relink_layout(records, from_source):
 
     relinked = relink(records)
     return relinked if kept else None
+
+
+def _nesting_depth(records, at=0):
+    """How many bone commands deep the layout goes"""
+    worst = at
+    for record in records:
+        if record[0] == "bonebranch":
+            worst = max(worst, _nesting_depth(record[2], at + 1))
+        elif record[0] == "selector":
+            for option in record[2]:
+                worst = max(worst, _nesting_depth(option, at))
+        elif record[0] == "sort":
+            worst = max(worst, _nesting_depth(record[3], at), _nesting_depth(record[4], at))
+        elif record[0] in ("lod", "drawdist", "camera"):
+            worst = max(worst, _nesting_depth(record[-1], at))
+    return worst
+
+
+def guard_layout(records, warnings):
+    """The stored layout with out of range Selectors dropped and deep nesting flattened"""
+    past_table = []
+    hoisted = 0
+
+    def guard(nodes, depth):
+        nonlocal hoisted
+        out = []
+        for record in nodes:
+            kind = record[0]
+            if kind == "selector" and not 1 <= record[1] <= MAX_APPENDAGE_ID:
+                # modelRender_geoCmd_SELECTOR indexes its table with this unchecked
+                past_table.append(record[1])
+                out += guard(record[2][0] if record[2] else [], depth)
+            elif kind == "bonebranch":
+                under = [child for child in record[2] if child[0] == "bonebranch"]
+                # this bone sits at depth + 1, so the bones under it sit one past that
+                if depth + 2 <= MAX_BONE_NESTING or not under:
+                    out.append(("bonebranch", record[1], guard(record[2], depth + 1)))
+                else:
+                    hoisted += len(under)
+                    own = [child for child in record[2] if child[0] != "bonebranch"]
+                    out.append(("bonebranch", record[1], guard(own, depth + 1)))
+                    out += guard(under, depth)
+            elif kind == "selector":
+                out.append(("selector", record[1], [guard(option, depth) for option in record[2]]))
+            elif kind == "sort":
+                out.append((*record[:3], guard(record[3], depth), guard(record[4], depth), record[5]))
+            elif kind in ("lod", "drawdist", "camera"):
+                out.append((*record[:-1], guard(record[-1], depth)))
+            else:
+                out.append(record)
+        return out
+
+    guarded = guard(records, 0)
+    if past_table:
+        named = ", ".join(str(value) for value in sorted(set(past_table)))
+        warnings.append(
+            f"{len(past_table)} Selectors name appendages {named}. The game's table stops at "
+            f"{MAX_APPENDAGE_ID} and it doesn't check, so each went out drawing its first option. Mark a "
+            f"bone Selector with an id from 1 to {MAX_APPENDAGE_ID} to gate that geometry again."
+        )
+    if hoisted:
+        warnings.append(
+            f"The layout nests bone commands {_nesting_depth(records)} deep and the matrix stack "
+            f"holds {MAX_BONE_NESTING}. {hoisted} of them went out beside their parent instead of inside "
+            "it. Nothing moves, since a bone loads its own matrix."
+        )
+    return guarded
 
 
 def layout_refpoints(records):

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -11,7 +11,7 @@ import bpy
 import mathutils
 
 from ...f3d.f3d_enums import combiner_enums
-from ...f3d.f3d_gbi import VTX_SIZE
+from ...f3d.f3d_gbi import MTX_SIZE, VTX_SIZE
 from ...f3d.f3d_material import (
     createF3DMat,
     update_node_values_of_material,
@@ -35,6 +35,7 @@ from .bk64_constants import (
     GEO_CMD_SKINNING,
     GEO_CMD_SORT,
     GEO_CMD_TEXWRAP,
+    GEO_CMD_BT_DRAW_SLOTS,
     GEO_CMD_UNK0,
     CAMERA_AREA_KIND,
     GEO_LAYOUT_PROP,
@@ -45,21 +46,24 @@ from .bk64_constants import (
     MIP_PYRAMID_SIZE,
     BK64_DRAW_LAYER_ENTRY,
     COLLISION_GRID_PROP,
+    G_MTX_PUSH,
     OP_DL,
     OP_CLEARGEOMETRYMODE,
     OP_ENDDL,
+    OP_MTX,
     OP_SETCOMBINE,
     OP_SETENVCOLOR,
     OP_SETGEOMETRYMODE,
     OP_SETPRIMCOLOR,
     OP_SETTILE,
+    OP_TEXTURE,
     OP_POPMTX,
     OP_SETTIMG,
-    OP_TEXTURE,
     OP_TRI1,
     OP_TRI2,
     OP_VTX,
     ANIM_TEX_SLOT_COUNT,
+    BT_ANIM_TEX_SLOT_COUNT,
     COLLISION_COLOR_ATTR,
     COLLISION_ONLY_PROP,
     COLLISION_UV_ATTR,
@@ -73,6 +77,7 @@ from .bk64_constants import (
     TEX_FLAG_LOAD_AS_RAW,
     RENDERMODE_ENTRY_STRIDE,
     RT_BK_MODEL,
+    SEG_BT_BONE_MTX,
     SEG_RENDERMODE,
     SEG_TEX,
     SEG_ANIM_BASE,
@@ -89,7 +94,7 @@ from .bk64_collision import (
     read_collision,
     read_collision_shapes_data,
 )
-from .bk64_rom import is_bkmodelbin, layout_records, read_bkmodelbin_header, read_camera_area_list
+from .bk64_rom import BKMODEL_SECTIONS, is_bkmodelbin, layout_records, read_bkmodelbin_header, read_camera_area_list
 from .bk64_skeleton import bone_space_matrix, create_armature_from_bones, read_bone_table
 
 OTEX_FORMAT = {value: key for key, value in OTEX_TYPE.items()}
@@ -163,6 +168,7 @@ def _read_model(data: bytes):
         words=words,
         blob=blob,
         tex_infos=tex_infos,
+        external_textures=0,
         anim_scale=anim_scale,
         bones=bones,
         collision=collision,
@@ -178,47 +184,81 @@ def _read_model_bin(data: bytes):
     rather than by stepping over the one before it.
     """
     header = read_bkmodelbin_header(data)
+    # Tooie's header holds the same fields but pads to 0x50, and Kazooie's
+    # first section always starts at 0x38
+    tooie = min((header[name] for name in BKMODEL_SECTIONS if header[name]), default=0x38) >= 0x50
 
     words = []
     if header["gfx"]:
         count = struct.unpack_from(">I", data, header["gfx"])[0]
         words = [struct.unpack_from(">II", data, header["gfx"] + 8 + index * 8) for index in range(count)]
+        if tooie:
+            words = _as_f3dex(words)
 
+    # Tooie puts a section where Kazooie keeps its counts, and counts at 0x44
+    tri_count, vertex_count = (
+        struct.unpack_from(">HH", data, 0x44) if tooie else (header["tri_count"], header["vertex_count"])
+    )
     vertices = []
     if header["vtx"]:
         # a BKVertexList opens with the model's bounds, then the records
-        vertices = _vertex_records(data, header["vtx"] + 24, header["vertex_count"], ">")
+        vertices = _vertex_records(data, header["vtx"] + 24, vertex_count, ">")
 
-    tex_infos, blob = [], b""
+    tex_infos, blob, external = [], b"", 0
     if header["texture"]:
-        blob_size, count = struct.unpack_from(">iH", data, header["texture"])
-        for index in range(count):
-            offset, kind, width, height = struct.unpack_from(">ihxxBB", data, header["texture"] + 8 + index * 16)
-            tex_infos.append(dict(offset=offset, type=kind, width=width, height=height))
-        blob_at = header["texture"] + 8 + count * 16
-        blob = data[blob_at : blob_at + blob_size]
+        blob_size, count, tex_flags = struct.unpack_from(">iHH", data, header["texture"])
+        # Tooie drops the padding words: 8 bytes, and the locator comes first
+        stride, fields = (8, ">IhBB") if tooie else (16, ">ihxxBB")
+        if tooie and tex_flags & 0x100:
+            external = count  # the pixels are in a bank the whole game shares, and the locator indexes it
+        else:
+            for index in range(count):
+                offset, kind, width, height = struct.unpack_from(fields, data, header["texture"] + 8 + index * stride)
+                tex_infos.append(dict(offset=offset, type=kind & 0x7FFF, width=width, height=height))
+            blob_at = header["texture"] + 8 + count * stride
+            blob = data[blob_at : blob_at + blob_size]
+
+    bound = []
+    if header["anim_vertices"]:
+        at = header["anim_vertices"]
+        if tooie:
+            # Tooie's table has no count to step by, so it runs to whatever section starts next
+            after = [header[name] for name in BKMODEL_SECTIONS if header[name] > at]
+            bound = _read_tooie_bound_vertices(data, at, min(after, default=len(data)), len(vertices))[0]
+        else:
+            bound = _read_bound_vertices(data, at, ">", True)[0]
 
     anim_scale, bones = read_bone_table(data)
-    bin_collision = read_bin_collision(data, header["collision"]) if header["collision"] else ({}, None)
+    surfaces, grid = read_bin_collision(data, header["collision"]) if header["collision"] else ({}, None)
+    if tooie:
+        # Tooie's unk6 counts triangles, not surfaces, so keeping it would split a material per face
+        surfaces = {triple: (flags, 0) for triple, (flags, _unk6) in surfaces.items()}
     model = dict(
         geo_type=header["geo_type"],
-        tri_count=header["tri_count"],
+        tri_count=tri_count,
         has_mesh_list=bool(header["mesh_list"]),
-        camera_areas=read_camera_area_list(data, header["camera"], ">", True) if header["camera"] else [],
-        mesh_list=_read_mesh_list(data, header["mesh_list"], ">")[0] if header["mesh_list"] else [],
-        bound_vertices=(
-            _read_bound_vertices(data, header["anim_vertices"], ">", True)[0] if header["anim_vertices"] else []
+        # Tooie fills these two slots with sections of its own, boxes where Kazooie
+        # keeps camera areas and vertex effects where it keeps the mesh list
+        camera_areas=(
+            read_camera_area_list(data, header["camera"], ">", True) if header["camera"] and not tooie else []
         ),
+        mesh_list=_read_mesh_list(data, header["mesh_list"], ">")[0] if header["mesh_list"] and not tooie else [],
+        bound_vertices=bound,
         animated_textures=(
-            _read_animated_textures(data, header["animated_texture"], ">") if header["animated_texture"] else []
+            _read_animated_textures(
+                data, header["animated_texture"], ">", BT_ANIM_TEX_SLOT_COUNT if tooie else ANIM_TEX_SLOT_COUNT
+            )
+            if header["animated_texture"]
+            else []
         ),
         words=words,
         blob=blob,
         tex_infos=tex_infos,
+        external_textures=external,
         anim_scale=anim_scale,
         bones=bones,
-        collision=bin_collision[0],
-        collision_grid=bin_collision[1],
+        collision=surfaces,
+        collision_grid=grid,
         shapes=read_collision_shapes_data(data, header["unk14"], ">")[0] if header["unk14"] else None,
     )
     # the layout is written last and runs to the end of the file
@@ -269,9 +309,62 @@ def _read_bound_vertices(data: bytes, offset: int, endian: str = "<", pad_header
     return entries, offset
 
 
-def _read_animated_textures(data: bytes, offset: int, endian: str):
+def _read_tooie_bound_vertices(data: bytes, offset: int, end: int, vertex_count: int):
+    """([{coord, bone, vertices}], where the section ends), from Tooie's table"""
+    flag, entries = struct.unpack_from(">HH", data, offset)
+    at = offset + 4
+    out = []
+    for _entry in range(entries):
+        entry_at = at
+        bone, points = struct.unpack_from(">HH", data, at)
+        at += 4
+        coords = [struct.unpack_from(">3h", data, at + step * 6) for step in range(points)]
+        at += points * 6 + 2  # the trailing word belongs to neither side
+
+        # flag 1 puts one normal per index here, ahead of the groups that say how many
+        groups, held = None, None
+        for skip in range(0, end - at, 4) if flag else (0,):
+            found = _read_index_groups(data, at + skip, end, points, vertex_count)
+            if found is None:
+                continue
+            reached, total, _held = found
+            if not flag or reached - entry_at == 6 + 8 * points + 6 * total:
+                groups, held = reached, _held
+                break
+        if groups is None:
+            raise PluginError(
+                f"The vertex binding table at 0x{offset:X} stops making sense at entry {_entry}. "
+                "This isn't a table the importer knows how to read."
+            )
+        at = groups
+        for coord, indices in zip(coords, held):
+            out.append(dict(coord=coord, bone=bone, vertices=indices))
+    return out, at
+
+
+def _read_index_groups(data: bytes, at: int, end: int, count: int, vertex_count: int):
+    """(where they end, how many indices, the groups), or None if the bytes aren't groups"""
+    groups, total = [], 0
+    for _group in range(count):
+        held = []
+        while True:
+            if at + 2 > end:
+                return None
+            value = struct.unpack_from(">h", data, at)[0]
+            at += 2
+            if value in (-1, -2):
+                break
+            if not 0 <= value < vertex_count:
+                return None
+            held.append(value)
+            total += 1
+        groups.append(held)
+    return at, total, groups
+
+
+def _read_animated_textures(data: bytes, offset: int, endian: str, slots: int = ANIM_TEX_SLOT_COUNT):
     """One (frame_size, frame_count, rate) per slot, s16 s16 f32 each"""
-    return [struct.unpack_from(endian + "hhf", data, offset + slot * 8) for slot in range(ANIM_TEX_SLOT_COUNT)]
+    return [struct.unpack_from(endian + "hhf", data, offset + slot * 8) for slot in range(slots)]
 
 
 def _read_rest(data: bytes, offset: int, flags):
@@ -441,6 +534,15 @@ def read_geo_body(body: bytes, endian: str = "<"):
                 offset, count, flags = struct.unpack_from(endian + "hBB", body, pos + 8)
                 ids = list(struct.unpack_from(endian + f"{count}B", body, pos + 12)) if count else []
                 records.append(("camera", ids, flags, branch(pos, offset)))
+            elif cmd in GEO_CMD_BT_DRAW_SLOTS:
+                # Tooie draws through these instead of LOADDL, and each slot holds
+                # a sub-list's offset in commands where LOADDL holds an index
+                for slot in range(GEO_CMD_BT_DRAW_SLOTS[cmd]):
+                    if pos + 10 + slot * 2 > len(body):
+                        break  # one model's last command runs four bytes past the file
+                    at = struct.unpack_from(endian + "H", body, pos + 8 + slot * 2)[0]
+                    if slot == 0 or at:
+                        records.append(("loaddl", at))
             elif cmd == GEO_CMD_TEXWRAP:
                 records.append(("texwrap", struct.unpack_from(endian + "i", body, pos + 8)[0]))
             elif cmd in (GEO_CMD_UNK0, GEO_CMD_CALL):
@@ -637,10 +739,7 @@ def _blob_textures(tex_infos):
     for index, info in enumerate(tex_infos):
         otex_format = BK_TEX_FORMAT.get(info["type"])
         if otex_format is None:
-            raise PluginError(
-                f"Texture {index} is type 0x{info['type']:X}, which is none of BK's. Tooie models land "
-                "here, since their texture entries are 8 bytes and lead with the offset, not the type."
-            )
+            raise PluginError(f"Texture {index} is type 0x{info['type']:X}, which is none of BK's.")
         palette = BK_PALETTE_SIZE[otex_format] if otex_format in PALETTED_FORMATS else 0
         textures.append(
             dict(
@@ -743,9 +842,60 @@ def new_walk_state():
         "vertex_owner": {},
         "chunk_owner": None,
         "chunk_parent": None,
+        "mtx_owner": None,
+        "mtx_stack": [],
+        "anim_slots": ANIM_TEX_SLOT_COUNT,
         "texscale": None,
         "dropped": 0,
     }
+
+
+def _f3dex_geomode(bits: int):
+    """F3DEX2's geometry mode bits, moved to where F3DEX keeps them"""
+    moved = ((bits & 0x600) << 3) | ((bits & 0x200000) >> 12)  # the two cull bits, then smooth shading
+    return (bits & ~0x200600 & 0xFFFFFF) | moved
+
+
+def _as_f3dex(words):
+    """Tooie's F3DEX2 commands as the F3DEX ones they correspond to, one for one"""
+    out = []
+    for w0, w1 in words:
+        op = w0 >> 24
+        if op == 0x01:  # G_VTX. F3DEX2 counts up to the last slot, F3DEX from the first
+            count = (w0 >> 12) & 0xFF
+            first = ((w0 & 0xFF) >> 1) - count
+            out.append(((OP_VTX << 24) | ((first * 2) << 16) | (count << 10), w1))
+        elif op == 0x05:  # G_TRI1, its indices move from w0 to w1
+            out.append((OP_TRI1 << 24, w0 & 0xFFFFFF))
+        elif op == 0x06:  # G_TRI2
+            out.append(((OP_TRI2 << 24) | (w0 & 0xFFFFFF), w1 & 0xFFFFFF))
+        elif op == 0xD9:
+            # G_GEOMETRYMODE clears and sets in one command. No model in the game
+            # does both at once, so it becomes whichever half it uses.
+            clear = ~w0 & 0xFFFFFF
+            if clear:
+                out.append((OP_CLEARGEOMETRYMODE << 24, _f3dex_geomode(clear)))
+            else:
+                out.append((OP_SETGEOMETRYMODE << 24, _f3dex_geomode(w1)))
+        elif op == 0xD7:  # G_TEXTURE, the level and tile move down a byte
+            out.append(((OP_TEXTURE << 24) | (((w0 >> 8) & 0xFF) << 8) | (w0 & 0xFF), w1))
+        elif op == 0xDA:
+            # G_MTX, F3DEX2 stores the flags xor push and numbers them differently
+            flags = (w0 & 0xFF) ^ 0x01
+            flags = (flags & 0x02) | ((flags & 0x01) << 2) | ((flags & 0x04) >> 2)
+            out.append(((OP_MTX << 24) | (flags << 16) | MTX_SIZE, w1))
+        elif op == 0xD8:
+            # G_POPMTX. F3DEX pops one at a time, so w1 keeps the count times MTX_SIZE
+            out.append((OP_POPMTX << 24, w1))
+        elif op == 0xDE:
+            out.append(((OP_DL << 24) | (w0 & 0xFFFFFF), w1))
+        elif op == 0xDF:
+            out.append((OP_ENDDL << 24, w1))
+        elif op in (0x02, 0x03, 0x04, 0x07, 0xDB, 0xDC, 0xDD):
+            out.append((0, 0))  # the rest, kept as nothing so a layout's command offsets still land
+        else:
+            out.append((w0, w1))  # the RDP half is shared
+    return out
 
 
 def _walk_display_list(words, start: int, state):
@@ -793,9 +943,10 @@ def _walk_display_list(words, start: int, state):
             first = ((w0 >> 16) & 0xFF) // 2
             count = (w0 & 0xFFFF) >> 10
             base = (w1 & 0xFFFFFF) // VTX_SIZE
+            owner = current_owner if state["mtx_owner"] is None else state["mtx_owner"]
             for step in range(count):
                 cache[first + step] = base + step
-                state["vertex_owner"][base + step] = current_owner
+                state["vertex_owner"][base + step] = owner
         elif opcode == OP_SETTIMG:
             segment, value = w1 >> 24, w1 & 0x00FFFFFF
             state["mip_tile"] = None
@@ -803,7 +954,7 @@ def _walk_display_list(words, start: int, state):
                 state["texture"] = value
                 if state["palette"] is not None:
                     palettes.setdefault(value, state["palette"])
-            elif SEG_ANIM_BASE - ANIM_TEX_SLOT_COUNT < segment <= SEG_ANIM_BASE:
+            elif SEG_ANIM_BASE - state["anim_slots"] < segment <= SEG_ANIM_BASE:
                 # an animated texture is bound by segment, and the game slides
                 # that segment along the blob a frame at a time
                 slot = SEG_ANIM_BASE - segment
@@ -847,7 +998,15 @@ def _walk_display_list(words, start: int, state):
             # a chunk picks its render mode by jumping into the game's table, and
             # one that never jumps keeps whatever the chunk before it left
             state["rendermode"] = (w1 & 0xFFFFFF) // RENDERMODE_ENTRY_STRIDE
+        elif opcode == OP_MTX and (w1 >> 24) == SEG_BT_BONE_MTX:
+            # a Tooie draw loads its bone's matrix inline. 85 of the game's pops
+            # land in a later chunk than their push, so the stack has to carry
+            if (w0 >> 16) & G_MTX_PUSH:
+                state["mtx_stack"].append(state["mtx_owner"])
+            state["mtx_owner"] = (w1 & 0xFFFFFF) // MTX_SIZE
         elif opcode == OP_POPMTX:
+            for _pop in range(w1 // MTX_SIZE):
+                state["mtx_owner"] = state["mtx_stack"].pop() if state["mtx_stack"] else None
             current_owner = state["chunk_parent"]
         elif opcode == OP_TRI1:
             emit(w1)
@@ -1250,6 +1409,7 @@ def import_bk64_model(context, path: str, settings):
     state = new_walk_state()
     if textures is not None:
         state["blob_images"] = {texture["image"]: index for index, texture in enumerate(textures)}
+    state["anim_slots"] = len(model["animated_textures"]) or ANIM_TEX_SLOT_COUNT
     geometry = []
     for matrix_id, parent_id, gfx_index in chunks:
         state["chunk_owner"], state["chunk_parent"] = matrix_id, parent_id
@@ -1261,7 +1421,9 @@ def import_bk64_model(context, path: str, settings):
     else:
         images = _load_blob_textures(base, model["blob"], textures, state["mip_textures"])
 
-    model["animated_frames"] = _load_animated_frames(base, model, state["anim_binds"], images)
+    model["animated_frames"] = (
+        {} if model["external_textures"] else _load_animated_frames(base, model, state["anim_binds"], images)
+    )
 
     # six models list textures their display list never binds, up to 81 of them.
     # Nothing here samples one, and nothing writes one back.

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -1275,7 +1275,8 @@ def import_bk64_model(context, path: str, settings):
         armature_obj = create_armature_from_bones(
             base + "_skel", model["bones"], bone_space_matrix(settings.scale), settings.bone_length
         )
-        bone_names = {index: bone.name for index, bone in enumerate(armature_obj.data.bones)}
+        # Blender lists bones by tree, and two Kazooie tables aren't in tree order
+        bone_names = {bone.hm64_bk64_bone_order: bone.name for bone in armature_obj.data.bones}
 
     # BK is Y up and in its own units
     to_blender = (

--- a/fast64_internal/hm64/bk64/bk64_import.py
+++ b/fast64_internal/hm64/bk64/bk64_import.py
@@ -36,6 +36,9 @@ from .bk64_constants import (
     GEO_CMD_SORT,
     GEO_CMD_TEXWRAP,
     GEO_CMD_BT_DRAW_SLOTS,
+    BT_DRAW_COMMAND_WORDS,
+    BT_HITBOX_SIZES,
+    BT_UNK20_SIZE,
     GEO_CMD_UNK0,
     CAMERA_AREA_KIND,
     GEO_LAYOUT_PROP,
@@ -77,6 +80,7 @@ from .bk64_constants import (
     TEX_FLAG_LOAD_AS_RAW,
     RENDERMODE_ENTRY_STRIDE,
     RT_BK_MODEL,
+    RT_BT_MODEL,
     SEG_BT_BONE_MTX,
     SEG_RENDERMODE,
     SEG_TEX,
@@ -94,8 +98,15 @@ from .bk64_collision import (
     read_collision,
     read_collision_shapes_data,
 )
-from .bk64_rom import BKMODEL_SECTIONS, is_bkmodelbin, layout_records, read_bkmodelbin_header, read_camera_area_list
-from .bk64_skeleton import bone_space_matrix, create_armature_from_bones, read_bone_table
+from .bk64_rom import (
+    BKMODEL_SECTIONS,
+    BTMODEL_RESOURCE_FIELDS,
+    is_bkmodelbin,
+    layout_records,
+    read_bkmodelbin_header,
+    read_camera_area_list,
+)
+from .bk64_skeleton import BK64Bone, bone_space_matrix, create_armature_from_bones, read_bone_table
 
 OTEX_FORMAT = {value: key for key, value in OTEX_TYPE.items()}
 BK_TEX_FORMAT = {value: key for key, value in BK_TEX_TYPE.items()}
@@ -104,6 +115,22 @@ BK_TEX_FORMAT = {value: key for key, value in BK_TEX_TYPE.items()}
 DRAW_LAYER_OF_ENTRY = {entry: layer for layer, entry in BK64_DRAW_LAYER_ENTRY.items() if entry is not None}
 
 SHAPE_CODE = "hm64_bk64_hit_code"  # the hit code the export reads back off a volume
+
+
+def _sibling(folder: str, base: str, suffix: str) -> bytes:
+    """One of the files a model resource is stored beside"""
+    path = os.path.join(folder, base + suffix)
+    if not os.path.exists(path):
+        raise PluginError(
+            f"'{base}{suffix}' isn't next to the model. A model is a family of files. "
+            "Extract the whole set, not just the one."
+        )
+    with open(path, "rb") as file:
+        return file.read()
+
+
+def is_btmodel(data: bytes) -> bool:
+    return len(data) >= 0x40 and struct.unpack_from("<I", data, 4)[0] == RT_BT_MODEL
 
 
 def _read_model(data: bytes):
@@ -174,6 +201,238 @@ def _read_model(data: bytes):
         collision=collision,
         collision_grid=collision_grid,
         shapes=shapes,
+    )
+
+
+def _bt_geo_body(opcode: int, take):
+    """One geo command's fields, at the widths Torch wrote them"""
+    if opcode == GEO_CMD_UNK0:
+        child = take("2H")[0]
+        take("3f")
+        return dict(child=child)
+    if opcode == GEO_CMD_SORT:
+        point = take("6f")
+        _unk18, _order, child, child2 = take("2B2H")
+        return dict(point=point, child=child, child2=child2)
+    if opcode == GEO_CMD_BONE:
+        child, bone, _unk = take("2BH")
+        return dict(child=child, bone=bone - 0x100 if bone > 0x7F else bone)
+    if opcode == GEO_CMD_LOADDL:
+        return dict(index=take("2H")[0])
+    if opcode == GEO_CMD_LOD:
+        far, near = take("2f")
+        return dict(far=far, near=near, point=take("3f"), child=take("I")[0])
+    if opcode == GEO_CMD_REFPOINT:
+        index, bone = take("2H")
+        # the bone reads back signed, and a refpoint on no bone carries -1
+        return dict(index=index, bone=bone - 0x10000 if bone > 0x7FFF else bone, point=take("3f"))
+    if opcode == GEO_CMD_SELECTOR:
+        index = take("H")[0]
+        return dict(index=index, children=list(take(f"{take('I')[0]}I")))
+    if opcode == GEO_CMD_DRAWDIST:
+        box = take("6h")
+        return dict(low=box[:3], high=box[3:], child=take("2h")[0])
+    if opcode == GEO_CMD_CAMERA:
+        child, count, flags = take("H2B")
+        return dict(child=child, flags=flags, ids=list(take(f"{count}B")))
+    if opcode == GEO_CMD_TEXWRAP:
+        return dict(mode=take("i")[0])
+    if opcode in GEO_CMD_BT_DRAW_SLOTS:
+        return dict(slots=take(f"{BT_DRAW_COMMAND_WORDS[opcode]}H"))
+    take(f"{take('I')[0]}s")  # an opcode Tooie never writes, carried as its own bytes
+    return {}
+
+
+def _bt_layout(commands):
+    """The command tree as records, walked the way the game walks the section"""
+    visited = set()
+
+    def walk(start):
+        records, pos = [], start
+        while pos in commands and pos not in visited:
+            visited.add(pos)
+            opcode, length, body = commands[pos]
+            branch = walk(pos + body["child"]) if body.get("child") else []
+            if opcode == GEO_CMD_BONE:
+                records.append(("bonebranch", body["bone"], branch))
+            elif opcode == GEO_CMD_LOADDL:
+                records.append(("loaddl", body["index"]))
+            elif opcode == GEO_CMD_SELECTOR:
+                records.append(("selector", body["index"], [walk(pos + child) for child in body["children"]]))
+            elif opcode == GEO_CMD_SORT:
+                second = walk(pos + body["child2"]) if body["child2"] else []
+                records.append(("sort", body["point"][:3], body["point"][3:], branch, second, 0))
+            elif opcode == GEO_CMD_LOD:
+                records.append(("lod", body["far"], body["near"], body["point"], branch))
+            elif opcode == GEO_CMD_DRAWDIST:
+                records.append(("drawdist", body["low"], body["high"], branch))
+            elif opcode == GEO_CMD_REFPOINT:
+                records.append(("refpoint", body["index"], body["bone"], body["point"]))
+            elif opcode == GEO_CMD_CAMERA:
+                records.append(("camera", body["ids"], body["flags"], branch))
+            elif opcode == GEO_CMD_TEXWRAP:
+                records.append(("texwrap", body["mode"]))
+            elif opcode in GEO_CMD_BT_DRAW_SLOTS:
+                # only the leading words are sub-list offsets, the rest count vertices
+                slots = body["slots"][: GEO_CMD_BT_DRAW_SLOTS[opcode]]
+                records += [("loaddl", at) for slot, at in enumerate(slots) if slot == 0 or at]
+            else:
+                records += branch
+            if not length:
+                break
+            pos += length
+        return records
+
+    return walk(0)
+
+
+def _skip_bt_tail(take, skip):
+    """Step over the sections past the animated textures, which nothing here reads"""
+    take("2I")  # 0x40, its flag and where it sat, neither of which matters here
+    if take("I")[0]:  # Torch read it, so it ships as sets of records
+        _unk0, _unk4, set_count, _unk8, _unka, _size = take("6I")
+        for _set in range(set_count):
+            record_count = take("I")[0]
+            skip(record_count * 16)  # three coords, flags, a zero word and a color
+            for _group in range(record_count):  # one group per record, so neither is counted
+                skip(take("I")[0] * 2)
+            take("I")  # what closed the set
+    else:
+        take("4I")
+        skip(take("I")[0])
+
+    take("2I")  # 0x3C, entries of six floats over a range of vertices
+    for _entry in range(take("I")[0]):
+        take("6f")
+        _first, count = take("2H")
+        skip(count * 8)
+
+    take("2I")  # 0x30, a grid whose cells own runs of vertex indices
+    take("6h3H")
+    skip(take("I")[0] * 4)
+    skip(take("I")[0] * 2)
+
+    for _block in range(take("I")[0]):  # blocks no section offset points at
+        take("I6h4HfI4I")  # where it sat, its grid, and the counts of what follows
+        lists = take("I")[0]
+        skip(lists * 4)
+        for _list in range(lists):
+            take("5I6h")  # the list header and the box it covers
+            skip(take("I")[0] * 4)
+            skip(take("I")[0])
+            skip(take("I")[0])
+        skip(take("I")[0] * 20)
+    for _run in range(take("I")[0]):  # bytes no section claimed, kept as they were
+        take("I")
+        skip(take("I")[0])
+
+
+def _read_bt_model(data: bytes):
+    """(model, layout, textures) from a BTModel resource, which Torch ships decoded"""
+    if len(data) < 0x40 or struct.unpack_from("<I", data, 4)[0] != RT_BT_MODEL:
+        raise PluginError("Not a Tooie model resource. Point this at the model, not a _VTX or _tex sibling.")
+    at = 0x40
+
+    def take(fmt: str):
+        nonlocal at
+        values = struct.unpack_from("<" + fmt, data, at)
+        at += struct.calcsize("<" + fmt)
+        return values
+
+    def skip(count: int):
+        # not `at += take(...)`, which reads at before take advances it and drops the advance
+        nonlocal at
+        at += count
+
+    sections = dict(zip(BTMODEL_RESOURCE_FIELDS, take(f"{len(BTMODEL_RESOURCE_FIELDS)}I")))
+    take("I")  # a vertex header follows even when the flag says there is none
+    take("12h")
+
+    _dl_count, _unk, _sublists, word_count = take("4I")
+    raw = take(f"{word_count}I")  # counted in words, where a Gfx is two of them
+    words = _as_f3dex(list(zip(raw[0::2], raw[1::2])))
+
+    _blob_size, external, tex_count = take("3I")
+    tex_infos = []
+    for _texture in range(tex_count):
+        locator, kind, _extra, width, height, _colors, _offset, _size = take("8I")
+        tex_infos.append(dict(offset=locator, type=kind & 0x7FFF, width=width, height=height))
+    blob = take(f"{take('I')[0]}s")[0]
+
+    _geo_at, geo_count = take("2I")
+    commands = {}
+    for _command in range(geo_count):
+        offset, opcode, length = take("3I")
+        commands[offset] = (opcode, length, _bt_geo_body(opcode, take))
+
+    _has_anim, anim_scale, bone_count = take("IfI")
+    bones = []
+    for _bone in range(bone_count):
+        x, y, z, bone_id, parent = take("3f2H")
+        bones.append(BK64Bone(f"bone_{bone_id}", (x, y, z), bone_id, parent))
+
+    _has_collision, grid_count = take("2I")
+    surfaces, grid = {}, None
+    for number in range(grid_count):
+        low, high = take("3h"), take("3h")
+        _y_stride, _z_stride, scale = take("3H")
+        # a cube gives where its run starts and how long it is, and the grid wants the length
+        counts = [take("2H")[1] for _cube in range(take("I")[0])]
+        records = [take("4HI") for _triangle in range(take("I")[0])]
+        if number == 0:  # a second grid covers the same triangles, and nothing reads it
+            grid = dict(low=low, high=high, scale=scale, counts=counts, records=records)
+            # unk6 counts triangles here as well, so it stays out of the material key
+            surfaces = {tuple(sorted(record[:3])): (record[4], 0) for record in records}
+
+    take("Ih")  # the hitbox flag and the word beside it
+    for size in BT_HITBOX_SIZES:
+        skip(take("I")[0] * size)
+    take("I")  # unk20's flag
+    skip(take("I")[0] * BT_UNK20_SIZE)
+    for _effect in range(take("I")[0]):
+        take("H")  # a vertex animation group, which nothing here plays
+        skip(take("I")[0] * 2)
+    take("IH")  # unk28's flag and the word it opens with
+    bound = []
+    for _entry in range(take("I")[0]):
+        bone, _trailing = take("Hh")
+        coords = take(f"{take('I')[0]}h")
+        groups = [take(f"{take('I')[0]}h") for _group in range(take("I")[0])]
+        for slot, indices in enumerate(groups):
+            bound.append(dict(coord=coords[slot * 3 : slot * 3 + 3], bone=bone, vertices=list(indices)))
+
+    animated = [take("2Hf") for _slot in range(take("I")[0])]
+    # nothing left is imported, and walking it is what makes the check below mean something
+    _skip_bt_tail(take, skip)
+    if at != len(data):
+        raise PluginError(
+            f"Read {at} bytes of a {len(data)} byte model. Each section is found by stepping over the "
+            "one before, so not landing on the end means something was misread."
+        )
+
+    # the display list addresses the model's own texture block, the way a .bin does
+    textures = [] if external else _blob_textures(_retype_ci_from_tiles(words, tex_infos))
+    return (
+        dict(
+            geo_type=sections["geo_type"],
+            tri_count=sections["tri_count"],
+            has_mesh_list=False,
+            camera_areas=[],  # the slots these two sit in hold Tooie's own sections
+            mesh_list=[],
+            bound_vertices=bound,
+            animated_textures=animated,
+            words=words,
+            blob=b"" if external else blob,
+            tex_infos=[] if external else tex_infos,
+            external_textures=tex_count if external else 0,
+            anim_scale=anim_scale,
+            bones=bones,
+            collision=surfaces,
+            collision_grid=grid,
+            shapes=None,
+        ),
+        _bt_layout(commands),
+        textures,
     )
 
 
@@ -1386,20 +1645,13 @@ def import_bk64_model(context, path: str, settings):
     textures = None
     if is_bkmodelbin(data):
         model, vertices, layout, textures = _read_model_bin(data)
+    elif is_btmodel(data):
+        model, layout, textures = _read_bt_model(data)
+        vertices = _read_vertices(_sibling(folder, base, "_VTX"))
     else:
         model = _read_model(data)
-        siblings = {}
-        for suffix in ("_VTX", "_GEO"):
-            sibling = os.path.join(folder, base + suffix)
-            if not os.path.exists(sibling):
-                raise PluginError(
-                    f"'{base}{suffix}' isn't next to the model. A BK model is a family of files. "
-                    "Extract the whole set, not just the one."
-                )
-            with open(sibling, "rb") as file:
-                siblings[suffix] = file.read()
-        vertices = _read_vertices(siblings["_VTX"])
-        layout = read_geo_tree(siblings["_GEO"])
+        vertices = _read_vertices(_sibling(folder, base, "_VTX"))
+        layout = read_geo_tree(_sibling(folder, base, "_GEO"))
     model["geo_layout"] = layout
     geo_used = set()
     chunks = layout_chunks(layout, geo_used)

--- a/fast64_internal/hm64/bk64/bk64_model.py
+++ b/fast64_internal/hm64/bk64/bk64_model.py
@@ -71,6 +71,7 @@ from .bk64_geo import (
     fixup_chunk,
     flatten_gfx_list,
     geo_records,
+    guard_layout,
     layout_refpoints,
     relink_layout,
     split_skinning,
@@ -1465,6 +1466,7 @@ def export_bk64_model(context, root_obj, settings, shapes=None, collision_only=N
         if stored is not None:
             records = relink_layout(stored, from_source)
             if records is not None:
+                records = guard_layout(records, settings.warnings)
                 # anything the modeller added is outside the layout, hung off its
                 # bone at the end. Anything else draws plainly, off no matrix.
                 drawn = {index for _k, indices, _m, _p, _r in layout_records(records) for index in indices}

--- a/fast64_internal/hm64/bk64/bk64_operators.py
+++ b/fast64_internal/hm64/bk64/bk64_operators.py
@@ -670,6 +670,11 @@ class BK64_ImportModel(Operator):
                         f"{model['unbound_textures']} of its textures aren't bound by the display list, "
                         "so they won't be there on the way out."
                     )
+                if model["external_textures"]:
+                    notes.append(
+                        f"Its {model['external_textures']} textures are in Tooie's shared texture bank, "
+                        "not the model, so it came in untextured."
+                    )
                 if model["collision_only_object"] is not None:
                     faces = len(model["collision_only_object"].data.polygons)
                     notes.append(f"{faces} collision triangles sit on geometry nothing draws, in their own mesh.")

--- a/fast64_internal/hm64/bk64/bk64_presets.py
+++ b/fast64_internal/hm64/bk64/bk64_presets.py
@@ -116,6 +116,8 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_OPA_SURF2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
+# BK reads its own draw layer
+bpy.context.material.hm64_bk64_draw_layer = 'SCENE'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Shaded Solid'
@@ -229,6 +231,8 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_OPA_SURF2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
+# BK reads its own draw layer
+bpy.context.material.hm64_bk64_draw_layer = 'SCENE'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Shaded Texture'
@@ -342,6 +346,11 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_TEX_EDGE2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
+# BK reads its own draw layer, and a cutout gets no alpha on the opaque entry
+_scene_layer = bpy.context.scene.hm64_bk64_draw_layer
+bpy.context.material.hm64_bk64_draw_layer = (
+    'TRANSLUCENT_NO_AA' if _scene_layer.endswith('_NO_AA') else 'TRANSLUCENT'
+)
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Shaded Texture Cutout'
@@ -573,6 +582,8 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_OPA_SURF2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
+# BK reads its own draw layer
+bpy.context.material.hm64_bk64_draw_layer = 'SCENE'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Vertex Colored Texture'
@@ -686,6 +697,11 @@ f3d_mat.rdp_settings.rendermode_preset_cycle_2 = 'G_RM_AA_ZB_TEX_EDGE2'
 f3d_mat.draw_layer.name = ''
 f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
+# BK reads its own draw layer, and a cutout gets no alpha on the opaque entry
+_scene_layer = bpy.context.scene.hm64_bk64_draw_layer
+bpy.context.material.hm64_bk64_draw_layer = (
+    'TRANSLUCENT_NO_AA' if _scene_layer.endswith('_NO_AA') else 'TRANSLUCENT'
+)
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'BK Vertex Colored Texture Cutout'

--- a/fast64_internal/hm64/bk64/bk64_rom.py
+++ b/fast64_internal/hm64/bk64/bk64_rom.py
@@ -356,6 +356,32 @@ BKMODEL_BIN_FIELDS = (
 BKMODEL_BIN_VALUES = frozenset(("magic", "geo_type", "tri_count", "vertex_count", "unk34"))
 BKMODEL_SECTIONS = tuple(name for name in BKMODEL_BIN_FIELDS if name not in BKMODEL_BIN_VALUES)
 
+# a BTModel resource opens with the same header, every field widened to a u32 and the
+# magic gone
+BTMODEL_RESOURCE_FIELDS = (
+    "geo",
+    "texture",
+    "geo_type",
+    "gfx",
+    "vtx",
+    "unk14",
+    "anim",
+    "collision",
+    "unk20",
+    "effects",
+    "unk28",
+    "animated_texture",
+    "section30",
+    "unk34",
+    "vtx_records_end",
+    "section3c",
+    "section40",
+    "tri_count",
+    "vertex_count",
+    "unk48",
+    "unk4c",
+)
+
 
 def is_bkmodelbin(data: bytes) -> bool:
     return len(data) >= BKMODEL_HEADER_SIZE and struct.unpack_from(">I", data, 0)[0] == BKMODEL_MAGIC

--- a/fast64_internal/hm64/bk64/bk64_rom.py
+++ b/fast64_internal/hm64/bk64/bk64_rom.py
@@ -354,6 +354,7 @@ BKMODEL_BIN_FIELDS = (
 
 # the header fields that are values rather than offsets to a section
 BKMODEL_BIN_VALUES = frozenset(("magic", "geo_type", "tri_count", "vertex_count", "unk34"))
+BKMODEL_SECTIONS = tuple(name for name in BKMODEL_BIN_FIELDS if name not in BKMODEL_BIN_VALUES)
 
 
 def is_bkmodelbin(data: bytes) -> bool:


### PR DESCRIPTION
- Banjo-Tooie models import, from a `.bin` or out of `bt.o2r`. Its F3DEX2 display lists are rewritten one command for one, and both paths give identical results. Export still writes Kazooie.
- Tooie rigs load bone matrices inline rather than through the layout, so the walker carries a matrix stack across chunks.
- Models that use textures from Tooie's shared texture bank import untextured, with a note to explain.
- Imported geo layouts are now checked on the way out. A Selector naming an appendage past 41, or bones nested past the RSP's matrix stack, get corrected with a warning saying what changed. Vanilla's 823 models pass through untouched.
- Every chunk opens with vanilla's geometry mode clear, so a double-sided chunk keeps both sides instead of inheriting `G_CULL_BACK` from whatever drew before it. TTC's fences and ship ropes draw correctly again. Reported by ThingyPerson.
- Bone names key off the stored table order rather than Blender's enumeration, so a model whose table isn't in tree order (`0428`, `048C`) keeps its geometry on the right bone.