### PR TITLE
Fix CI4 textures showing wrong in Banjo's Backpack

### DIFF
--- a/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
+++ b/fast64_internal/hm64/f3d/f3d_texture_writer_hm64.py
@@ -431,6 +431,9 @@ def writeAll(self, fMaterial: FMaterial, fModel: Union[FModel, FTexRect], conver
             loadGfx, fPalette, self.palFormat, self.palAddr, self.palLen, 5 - self.indexInMat, f3d
         )
         override = getattr(self.texProp, "palette_color_count", None) if self.texProp is not None else None
+        if is_bk64() and self.texProp is not None:
+            # Banjo's Backpack sizes the palette off this count and only knows 16 or 256
+            override = 15 if self.texProp.tex_format == "CI4" else 255
         if load_tlut_cmd is not None:
             load_tlut_cmd.count = max(0, min((override if override is not None else self.palLen - 1), 255))
             if shared_tlut_state is not None and fPalette is not None:


### PR DESCRIPTION
- The LOADTLUT count came from the Color Count override, which defaults to 255. Banjo's Backpack sizes the palette off that count and only knows 16 or 256, so a fresh CI4 material read as 512 bytes of palette and BB never found the index data behind it. The game reads the first 16 entries either way, which is why it rendered fine in ROM. Reported by Sorra.
- BK64 now writes 15 for CI4 and 255 for CI8 regardless of the override. Imported vanilla materials already carried 15, so only user-made CI4 materials change.
- Tested by exporting a CI4 cube from a fresh scene and walking the `.bin` the way BB's `Texture.loadPalette` does. Before, the index SETTIMG at `+0x20` never matched; after, it does.
